### PR TITLE
ci: Use buildbuddy for a remote cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,8 @@
 # `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=fixtures/simple/output_base/external/bar,fixtures/simple/output_base/external/foo,fixtures/simple/root,fixtures/simple/root/foo
 query --deleted_packages=fixtures/simple/output_base/external/bar,fixtures/simple/output_base/external/foo,fixtures/simple/root,fixtures/simple/root/foo
+
+build:ci --bes_results_url=https://bazel-lsp.buildbuddy.io/invocation/
+build:ci --bes_backend=grpcs://bazel-lsp.buildbuddy.io
+build:ci --remote_cache=grpcs://bazel-lsp.buildbuddy.io
+build:ci --remote_timeout=3600

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,10 +26,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Authenticate with buildbuddy
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          echo "build:ci --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" >> ~/.bazelrc
       - name: Build & Test
         run: |
-          cargo --version
-          bazel test //... -c opt
+          bazel test //... -c opt --config=ci
       - uses: actions/upload-artifact@v4
         with:
           name: bazel-lsp-${{ matrix.target.name }}${{ matrix.target.extension }}


### PR DESCRIPTION
This should drop the build time by a significant amount.