### PR TITLE
fix: Update starlark crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,13 +29,14 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
- "getrandom",
+ "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -49,25 +50,31 @@ dependencies = [
 
 [[package]]
 name = "allocative"
-version = "0.3.1"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+version = "0.3.2"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "allocative_derive",
  "bumpalo",
  "ctor",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.3",
  "num-bigint",
 ]
 
 [[package]]
 name = "allocative_derive"
-version = "0.3.1"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+version = "0.3.2"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "annotate-snippets"
@@ -387,7 +394,7 @@ dependencies = [
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 
 [[package]]
 name = "colorchoice"
@@ -497,7 +504,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "either",
  "indenter",
@@ -506,7 +513,7 @@ dependencies = [
 [[package]]
 name = "dupe"
 version = "0.9.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "dupe_derive",
 ]
@@ -514,7 +521,7 @@ dependencies = [
 [[package]]
 name = "dupe_derive"
 version = "0.9.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -704,15 +711,16 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1701,8 +1709,8 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "starlark"
-version = "0.11.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+version = "0.12.0"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "allocative",
  "anyhow",
@@ -1715,7 +1723,7 @@ dependencies = [
  "dupe",
  "either",
  "erased-serde",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.3",
  "inventory",
  "itertools 0.10.5",
  "maplit",
@@ -1739,8 +1747,8 @@ dependencies = [
 
 [[package]]
 name = "starlark_derive"
-version = "0.11.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+version = "0.12.0"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "dupe",
  "proc-macro2",
@@ -1750,8 +1758,8 @@ dependencies = [
 
 [[package]]
 name = "starlark_lsp"
-version = "0.11.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+version = "0.12.0"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "anyhow",
  "derivative",
@@ -1769,21 +1777,21 @@ dependencies = [
 
 [[package]]
 name = "starlark_map"
-version = "0.11.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+version = "0.12.0"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "allocative",
  "dupe",
  "equivalent",
  "fxhash",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
 [[package]]
 name = "starlark_syntax"
-version = "0.11.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#a1fda55946615fe5a58e0c0a29832877ed55b4e1"
+version = "0.12.0"
+source = "git+https://github.com/facebookexperimental/starlark-rust.git?rev=cf5e6b8cb8bb364c8c49b67080e510916c502d4b#cf5e6b8cb8bb364c8c49b67080e510916c502d4b"
 dependencies = [
  "allocative",
  "annotate-snippets",
@@ -2347,3 +2355,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ prost-types = "0.12.3"
 protoc-gen-prost = "0.2.3"
 protoc-gen-tonic = "0.3.0"
 ring = "0.17.7"
-starlark = { git = "https://github.com/facebookexperimental/starlark-rust.git", branch = "main" }
-starlark_lsp = { git = "https://github.com/facebookexperimental/starlark-rust.git", branch = "main" }
+starlark = { git = "https://github.com/facebookexperimental/starlark-rust.git", rev = "cf5e6b8cb8bb364c8c49b67080e510916c502d4b" }
+starlark_lsp = { git = "https://github.com/facebookexperimental/starlark-rust.git", rev = "cf5e6b8cb8bb364c8c49b67080e510916c502d4b" }
 thiserror = "1.0.56"
 tonic = "0.10.2"


### PR DESCRIPTION
This fixes some issues with autocomplete popups being too sensitive. However, this does not update to the latest commit due to https://github.com/facebookexperimental/starlark-rust/issues/112.