### PR TITLE
ci: Cache repository rules

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,9 +39,9 @@ jobs:
         with:
           path: |
             ${{ runner.temp }}/.bazel/output_base/external
-          key: bazel-${{ runner.os }}-${{ github.ref }}
+          key: bazel-${{ matrix.target.name }}-${{ github.ref }}
           restore-keys:
-            bazel-${{ runner.os }}-master
+            bazel-${{ matrix.target.name }}-refs/heads/master
       - name: Build & Test
         run: |
           INVOCATION_ID="$(uuidgen)"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,11 +34,11 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           echo "build:ci --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" >> ~/.bazelrc
-          echo "startup --output_base=$HOME/.bazel/output_base" >> ~/.bazelrc
+          echo "startup --output_base=$RUNNER_TEMP/.bazel/output_base" >> ~/.bazelrc
       - uses: actions/cache@v4
         with:
           path: |
-            ${{ env.HOME }}/.bazel/output_base/external
+            ${{ runner.temp }}/.bazel/output_base/external
           key: bazel-${{ runner.os }}-${{ github.ref }}
           restore-keys:
             bazel-${{ runner.os }}-master

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,11 +29,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Authenticate with buildbuddy
+      - name: Set up bazelrc
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           echo "build:ci --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" >> ~/.bazelrc
+          echo "startup --output_base=$HOME/.bazel/output_base" >> ~/.bazelrc
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.HOME }}/.bazel/output_base/external
+          key: bazel-${{ runner.os }}-${{ github.ref }}
+          restore-keys:
+            bazel-${{ runner.os }}-master
       - name: Build & Test
         run: |
           INVOCATION_ID="$(uuidgen)"


### PR DESCRIPTION
This uses github's caching to cache external repositories, since these are quite expensive to recreate.