### PR TITLE
Set version from Cargo.toml

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,6 +7,7 @@ rust_binary(
         "//src/builtin:builtin.pb",
         "//src/builtin:default_build_language.pb",
     ],
+    rustc_env_files = [":generate_rustc_env_file"],
     deps = [
         "//src/builtin:build_proto_rust",
         "//src/builtin:builtin_proto_rust",
@@ -21,6 +22,17 @@ rust_binary(
         "@crates//:starlark_lsp",
         "@crates//:thiserror",
     ],
+)
+
+genrule(
+    name = "generate_rustc_env_file",
+    srcs = [
+        "Cargo.toml",
+        "src/main.rs",
+    ],
+    outs = ["rustc_env_file"],
+    cmd = "echo \"CARGO_PKG_VERSION=$$($(location @rust_host_tools//:cargo) read-manifest | jq -r .version)\" > $@",
+    tools = ["@rust_host_tools//:cargo"],
 )
 
 rust_test(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,10 @@ rust.toolchain(
 use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")
 
+rust_host_tools = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
+
+use_repo(rust_host_tools, "rust_host_tools")
+
 crate = use_extension(
     "@rules_rust//crate_universe:extension.bzl",
     "crate",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "98dabca0e21165df3a944a9abe144e134687550f974feadb4b141d9e0cef7b52",
+  "moduleFileHash": "20bc37500b4e20315450ab03aed9ee88c643cf6588c549abee29937a5bdd927d",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -61,12 +61,29 @@
           "hasNonDevUseExtension": true
         },
         {
+          "extensionBzlFile": "@rules_rust//rust:extensions.bzl",
+          "extensionName": "rust_host_tools",
+          "usingModule": "<root>",
+          "location": {
+            "file": "@@//:MODULE.bazel",
+            "line": 11,
+            "column": 32
+          },
+          "imports": {
+            "rust_host_tools": "rust_host_tools"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
           "extensionBzlFile": "@rules_rust//crate_universe:extension.bzl",
           "extensionName": "crate",
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 11,
+            "line": 15,
             "column": 22
           },
           "imports": {
@@ -86,7 +103,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 15,
+                "line": 19,
                 "column": 17
               }
             },
@@ -101,7 +118,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 22,
+                "line": 26,
                 "column": 17
               }
             },
@@ -116,7 +133,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 27,
+                "line": 31,
                 "column": 17
               }
             }


### PR DESCRIPTION
This uses a genrule to read the Cargo.toml and set `CARGO_PKG_VERSION`. This is picked up by clap to set the version when asked via `--version`.

Fixes #39