### PR TITLE
Update starlark-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 [[package]]
 name = "allocative"
 version = "0.3.3"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "allocative_derive",
  "bumpalo",
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 name = "allocative_derive"
 version = "0.3.3"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -340,6 +340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,19 +387,17 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 
 [[package]]
 name = "colorchoice"
@@ -403,9 +407,12 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -462,15 +469,24 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.59",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -503,7 +519,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "either",
  "indenter",
@@ -512,7 +528,7 @@ dependencies = [
 [[package]]
 name = "dupe"
 version = "0.9.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "dupe_derive",
 ]
@@ -520,7 +536,7 @@ dependencies = [
 [[package]]
 name = "dupe_derive"
 version = "0.9.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -575,13 +591,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
 name = "fastrand"
@@ -591,13 +603,13 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fd-lock"
-version = "3.0.13"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1100,12 +1112,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -1542,15 +1555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,25 +1575,24 @@ checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "rustyline"
-version = "11.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "clipboard-win",
- "dirs-next",
  "fd-lock",
+ "home",
  "libc",
  "log",
  "memchr",
  "nix",
  "radix_trie",
- "scopeguard",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1645,12 +1648,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
@@ -1734,7 +1731,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "starlark"
 version = "0.12.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "allocative",
  "anyhow",
@@ -1773,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "starlark_derive"
 version = "0.12.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "dupe",
  "proc-macro2",
@@ -1784,7 +1781,7 @@ dependencies = [
 [[package]]
 name = "starlark_lsp"
 version = "0.12.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "anyhow",
  "derivative",
@@ -1803,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "starlark_map"
 version = "0.12.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "allocative",
  "dupe",
@@ -1816,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "starlark_syntax"
 version = "0.12.0"
-source = "git+https://github.com/facebookexperimental/starlark-rust.git?branch=main#293532ec1a4d1da232b4fe6b7f62ef174b7106fa"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
 dependencies = [
  "allocative",
  "annotate-snippets",
@@ -1841,12 +1838,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "string_cache"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ protoc-gen-tonic = "0.3.0"
 ring = "0.17.7"
 serde = "1.0.195"
 serde_json = "1.0.111"
-starlark = { git = "https://github.com/facebookexperimental/starlark-rust.git", branch = "main" }
-starlark_lsp = { git = "https://github.com/facebookexperimental/starlark-rust.git", branch = "main" }
+starlark = { git = "https://github.com/facebook/starlark-rust.git", branch = "main" }
+starlark_lsp = { git = "https://github.com/facebook/starlark-rust.git", branch = "main" }
 thiserror = "1.0.56"
 tonic = "0.10.2"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,9 +1,9 @@
-bazel_dep(name = "rules_rust", version = "0.46.0")
+bazel_dep(name = "rules_rust", version = "0.49.3")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
-    versions = ["1.78.0"],
+    versions = ["1.80.0"],
 )
 use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")
@@ -39,6 +39,6 @@ bazel_dep(
     dev_dependency = True,
 )
 
-bazel_dep(name = "protobuf", version = "23.1")
+bazel_dep(name = "protobuf", version = "27.1")
 
 register_toolchains("//prost:prost_toolchain")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -22,6 +22,7 @@
     "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/source.json": "c9320aa53cd1c441d24bd6b716da087ad7e4ff0d9742a9884587596edfe53015",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
     "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
@@ -46,6 +47,8 @@
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
     "https://bcr.bazel.build/modules/googletest/1.14.0/source.json": "2478949479000fdd7de9a3d0107ba2c85bb5f961c3ecb1aa448f52549ce310b5",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
@@ -54,8 +57,8 @@
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
     "https://bcr.bazel.build/modules/platforms/0.0.9/source.json": "cd74d854bf16a9e002fb2ca7b1a421f4403cda29f824a765acd3a8c56f8d43e6",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
-    "https://bcr.bazel.build/modules/protobuf/23.1/MODULE.bazel": "88b393b3eb4101d18129e5db51847cd40a5517a53e81216144a8c32dfeeca52a",
-    "https://bcr.bazel.build/modules/protobuf/23.1/source.json": "8eb4721d6793122d39e793d15ac7bb2d22f5214e0b6a8b7fd1f339a8facc27e4",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/27.1/source.json": "11a2567425ffebb89ff59e94fc8a55bc78a418d52a4cc415069ce7c793571352",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
     "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
     "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
@@ -80,7 +83,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/source.json": "8f3f3076554e1558e8e468b2232991c510ecbcbed9e6f8c06ac31c93bcf38362",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
-    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/source.json": "a075731e1b46bc8425098512d038d416e966ab19684a10a34f4741295642fc35",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/source.json": "5abb45cc9beb27b77aec6a65a11855ef2b55d95dfdc358e9f312b78ae0ba32d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
     "https://bcr.bazel.build/modules/rules_license/0.0.8/MODULE.bazel": "5669c6fe49b5134dbf534db681ad3d67a2d49cfc197e4a95f1ca2fd7f3aebe96",
@@ -91,22 +95,22 @@
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/source.json": "c2557066e0c0342223ba592510ad3d812d4963b9024831f7f66fd0584dd8c66c",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
-    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/source.json": "d57902c052424dfda0e71646cb12668d39c4620ee0544294d9d941e7d12bc3a9",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/source.json": "17a2e195f56cb28d6bbf763e49973d13890487c6945311ed141e196fb660426d",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
     "https://bcr.bazel.build/modules/rules_python/0.19.0/MODULE.bazel": "4dd47e473edf092240cb9835238762289028e58c691920ef5b92b6240d8db17a",
     "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel": "26114f0c0b5e93018c0c066d6673f1a2c3737c7e90af95eff30cfee38d0bbac7",
     "https://bcr.bazel.build/modules/rules_python/0.22.1/source.json": "57226905e783bae7c37c2dd662be078728e48fa28ee4324a7eabcafb5a43d014",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
-    "https://bcr.bazel.build/modules/rules_rust/0.46.0/MODULE.bazel": "9bc9cd48a10ec306399f2864988e94f3bf1227b4f239cb4e15145f76cec5a99a",
-    "https://bcr.bazel.build/modules/rules_rust/0.46.0/source.json": "1fe88a22bc1b24dbba44076ca82ced427a751d2df22f927494fdbc53e75c4bf8",
+    "https://bcr.bazel.build/modules/rules_rust/0.49.3/MODULE.bazel": "7c747ca20606b61fdb3c99c537a97a7cc89ac48482c0f25b3e70787297b0ec46",
+    "https://bcr.bazel.build/modules/rules_rust/0.49.3/source.json": "0f4627d0ed4cd0d5af58f0162f87dcdf38fe4578e5308a3d7dca4c68cb13e323",
     "https://bcr.bazel.build/modules/stardoc/0.5.0/MODULE.bazel": "f9f1f46ba8d9c3362648eea571c6f9100680efc44913618811b58cc9c02cd678",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
     "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
     "https://bcr.bazel.build/modules/stardoc/0.5.6/source.json": "956954c9c45ef492ea4001ce579dc40431fbd75090151e8f9eadf9ed6377a108",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
-    "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
-    "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/source.json": "b2150404947339e8b947c6b16baa39fa75657f4ddec5e37272c7b11c7ab533bc",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3/MODULE.bazel": "6a9c02f19a24dcedb05572b2381446e27c272cd383aed11d41d99da9e3167a72",
@@ -619,35 +623,6 @@
         "recordedRepoMappingEntries": []
       }
     },
-    "@@protobuf~//:non_module_deps.bzl%non_module_deps": {
-      "general": {
-        "bzlTransitiveDigest": "jsbfONl9OksDWiAs7KDFK5chH/tYI3DngdM30NKdk5Y=",
-        "usagesDigest": "UFx3bfmYpWpeHMGWvXk+IWxqaVn31vdAAEUAn0P9S5k=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "utf8_range": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/protocolbuffers/utf8_range/archive/de0b4a8ff9b5d4c98108bdfe723291a33c52c54f.zip"
-              ],
-              "strip_prefix": "utf8_range-de0b4a8ff9b5d4c98108bdfe723291a33c52c54f",
-              "sha256": "5da960e5e5d92394c809629a03af3c7709d2d3d0ca731dacb3a9fb4bf28f7702"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "protobuf~",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
     "@@rules_buf~//buf:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "gmPmM7QT5Jez2VVFcwbbMf/QWSRag+nJ1elFJFFTcn0=",
@@ -837,26 +812,25 @@
     },
     "@@rules_rust~//rust:extensions.bzl%rust": {
       "general": {
-        "bzlTransitiveDigest": "E0PTgt7FFtzIpCxiDP7I3cAgtHZQSXiUtCwTnrmGPc4=",
-        "usagesDigest": "Hg++VVdWMu56rWD9NXXShtmXww1nsRNr0LwrDQdxZd4=",
+        "bzlTransitiveDigest": "1o/b7Y8jEnrOScZ+yQtYRKKvtsG0oN4i7cwaXawLv3E=",
+        "usagesDigest": "IdLhWGRQjv892iEmVr/wsHsLM2wQUBlUXFvr210uCXY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "rustfmt_nightly-2024-05-02__aarch64-apple-darwin_tools": {
+          "rust_analyzer_1.80.0_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "ruleClassName": "rust_analyzer_toolchain_tools_repository",
             "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-05-02",
+              "version": "1.80.0",
+              "iso_date": "",
               "sha256s": {},
               "urls": [
                 "https://static.rust-lang.org/dist/{}.tar.xz"
               ],
               "auth": {},
               "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "aarch64-apple-darwin"
+              "auth_patterns": []
             }
           },
           "rust_windows_x86_64__wasm32-wasi__stable_tools": {
@@ -868,8 +842,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -893,8 +867,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -918,8 +892,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -934,6 +908,20 @@
               "auth_patterns": []
             }
           },
+          "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-07-25__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": []
+            }
+          },
           "rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
@@ -943,8 +931,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -987,8 +975,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1022,6 +1010,20 @@
               ]
             }
           },
+          "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
           "rust_windows_x86_64": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_set_repository",
@@ -1052,20 +1054,6 @@
               ]
             }
           },
-          "rustfmt_nightly-2024-05-02__x86_64-apple-darwin": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-05-02__x86_64-apple-darwin_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": []
-            }
-          },
           "rust_windows_aarch64__wasm32-wasi__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
@@ -1075,8 +1063,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1089,36 +1077,6 @@
               "auth": {},
               "netrc": "",
               "auth_patterns": []
-            }
-          },
-          "rustfmt_nightly-2024-05-02__aarch64-pc-windows-msvc_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-05-02",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "aarch64-pc-windows-msvc"
-            }
-          },
-          "rustfmt_nightly-2024-05-02__x86_64-pc-windows-msvc": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-05-02__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": []
             }
           },
           "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools": {
@@ -1130,8 +1088,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-unknown-linux-gnu",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1146,6 +1104,16 @@
               "auth_patterns": []
             }
           },
+          "rust_analyzer_1.80.0": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_analyzer_1.80.0_tools//:rust_analyzer_toolchain",
+              "toolchain_type": "@rules_rust//rust/rust_analyzer:toolchain_type",
+              "exec_compatible_with": [],
+              "target_compatible_with": []
+            }
+          },
           "rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
@@ -1155,8 +1123,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-pc-windows-msvc",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1182,6 +1150,20 @@
               ]
             }
           },
+          "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
           "rust_linux_x86_64__wasm32-unknown-unknown__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
@@ -1201,21 +1183,6 @@
               ]
             }
           },
-          "rust_analyzer_1.78.0_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_analyzer_toolchain_tools_repository",
-            "attributes": {
-              "version": "1.78.0",
-              "iso_date": "",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
           "rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
@@ -1225,8 +1192,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-pc-windows-msvc",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1239,6 +1206,22 @@
               "auth": {},
               "netrc": "",
               "auth_patterns": []
+            }
+          },
+          "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-07-25",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-unknown-freebsd"
             }
           },
           "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools": {
@@ -1250,8 +1233,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-unknown-freebsd",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1264,20 +1247,6 @@
               "auth": {},
               "netrc": "",
               "auth_patterns": []
-            }
-          },
-          "rustfmt_nightly-2024-05-02__aarch64-pc-windows-msvc": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-05-02__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": []
             }
           },
           "rust_darwin_x86_64__wasm32-unknown-unknown__stable": {
@@ -1356,6 +1325,22 @@
               ]
             }
           },
+          "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-07-25",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-unknown-linux-gnu"
+            }
+          },
           "rust_darwin_x86_64": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_set_repository",
@@ -1365,20 +1350,6 @@
                 "@rust_darwin_x86_64__wasm32-unknown-unknown__stable//:toolchain",
                 "@rust_darwin_x86_64__wasm32-wasi__stable//:toolchain"
               ]
-            }
-          },
-          "rustfmt_nightly-2024-05-02__aarch64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-05-02__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": []
             }
           },
           "rust_windows_aarch64__wasm32-wasi__stable": {
@@ -1409,8 +1380,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1434,8 +1405,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1459,8 +1430,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1505,6 +1476,22 @@
               ]
             }
           },
+          "rustfmt_nightly-2024-07-25__aarch64-apple-darwin_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-07-25",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-apple-darwin"
+            }
+          },
           "rust_darwin_x86_64__x86_64-apple-darwin__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
@@ -1533,8 +1520,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1558,8 +1545,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1591,20 +1578,6 @@
                 "@platforms//cpu:wasm32",
                 "@platforms//os:wasi"
               ]
-            }
-          },
-          "rustfmt_nightly-2024-05-02__x86_64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-05-02__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": []
             }
           },
           "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": {
@@ -1646,8 +1619,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1758,8 +1731,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1774,22 +1747,6 @@
               "auth_patterns": []
             }
           },
-          "rustfmt_nightly-2024-05-02__x86_64-pc-windows-msvc_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-05-02",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "x86_64-pc-windows-msvc"
-            }
-          },
           "rust_darwin_aarch64__aarch64-apple-darwin__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
@@ -1799,8 +1756,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-apple-darwin",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1824,8 +1781,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -1840,26 +1797,26 @@
               "auth_patterns": []
             }
           },
-          "rustfmt_nightly-2024-05-02__x86_64-unknown-freebsd": {
+          "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-05-02__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+              "toolchain": "@rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
               "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
               "target_settings": [],
               "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:freebsd"
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
               ],
               "target_compatible_with": []
             }
           },
-          "rustfmt_nightly-2024-05-02__x86_64-unknown-linux-gnu_tools": {
+          "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rustfmt_toolchain_tools_repository",
             "attributes": {
               "version": "nightly",
-              "iso_date": "2024-05-02",
+              "iso_date": "2024-07-25",
               "sha256s": {},
               "urls": [
                 "https://static.rust-lang.org/dist/{}.tar.xz"
@@ -1867,7 +1824,7 @@
               "auth": {},
               "netrc": "",
               "auth_patterns": {},
-              "exec_triple": "x86_64-unknown-linux-gnu"
+              "exec_triple": "aarch64-pc-windows-msvc"
             }
           },
           "rust_windows_aarch64__wasm32-unknown-unknown__stable": {
@@ -1889,6 +1846,20 @@
               ]
             }
           },
+          "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-07-25__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": []
+            }
+          },
           "rust_linux_aarch64": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_set_repository",
@@ -1898,6 +1869,22 @@
                 "@rust_linux_aarch64__wasm32-unknown-unknown__stable//:toolchain",
                 "@rust_linux_aarch64__wasm32-wasi__stable//:toolchain"
               ]
+            }
+          },
+          "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-07-25",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-unknown-linux-gnu"
             }
           },
           "rust_darwin_aarch64__wasm32-wasi__stable": {
@@ -1919,12 +1906,12 @@
               ]
             }
           },
-          "rustfmt_nightly-2024-05-02__aarch64-unknown-linux-gnu_tools": {
+          "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rustfmt_toolchain_tools_repository",
             "attributes": {
               "version": "nightly",
-              "iso_date": "2024-05-02",
+              "iso_date": "2024-07-25",
               "sha256s": {},
               "urls": [
                 "https://static.rust-lang.org/dist/{}.tar.xz"
@@ -1932,23 +1919,21 @@
               "auth": {},
               "netrc": "",
               "auth_patterns": {},
-              "exec_triple": "aarch64-unknown-linux-gnu"
+              "exec_triple": "x86_64-pc-windows-msvc"
             }
           },
-          "rustfmt_nightly-2024-05-02__x86_64-apple-darwin_tools": {
+          "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-05-02",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
+              "toolchain": "@rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
               ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "x86_64-apple-darwin"
+              "target_compatible_with": []
             }
           },
           "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": {
@@ -1970,26 +1955,12 @@
               ]
             }
           },
-          "rustfmt_nightly-2024-05-02__aarch64-apple-darwin": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-05-02__aarch64-apple-darwin_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rustfmt_nightly-2024-05-02__x86_64-unknown-freebsd_tools": {
+          "rustfmt_nightly-2024-07-25__x86_64-apple-darwin_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rustfmt_toolchain_tools_repository",
             "attributes": {
               "version": "nightly",
-              "iso_date": "2024-05-02",
+              "iso_date": "2024-07-25",
               "sha256s": {},
               "urls": [
                 "https://static.rust-lang.org/dist/{}.tar.xz"
@@ -1997,7 +1968,7 @@
               "auth": {},
               "netrc": "",
               "auth_patterns": {},
-              "exec_triple": "x86_64-unknown-freebsd"
+              "exec_triple": "x86_64-apple-darwin"
             }
           },
           "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": {
@@ -2019,13 +1990,17 @@
               ]
             }
           },
-          "rust_analyzer_1.78.0": {
+          "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_analyzer_1.78.0_tools//:rust_analyzer_toolchain",
-              "toolchain_type": "@rules_rust//rust/rust_analyzer:toolchain_type",
-              "exec_compatible_with": [],
+              "toolchain": "@rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
               "target_compatible_with": []
             }
           },
@@ -2034,100 +2009,100 @@
             "ruleClassName": "toolchain_repository_hub",
             "attributes": {
               "toolchain_names": [
-                "rust_analyzer_1.78.0",
+                "rust_analyzer_1.80.0",
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable",
                 "rust_darwin_aarch64__wasm32-unknown-unknown__stable",
                 "rust_darwin_aarch64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-05-02__aarch64-apple-darwin",
+                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable",
                 "rust_windows_aarch64__wasm32-unknown-unknown__stable",
                 "rust_windows_aarch64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-05-02__aarch64-pc-windows-msvc",
+                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable",
                 "rust_linux_aarch64__wasm32-unknown-unknown__stable",
                 "rust_linux_aarch64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-05-02__aarch64-unknown-linux-gnu",
+                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu",
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable",
                 "rust_darwin_x86_64__wasm32-unknown-unknown__stable",
                 "rust_darwin_x86_64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-05-02__x86_64-apple-darwin",
+                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable",
                 "rust_windows_x86_64__wasm32-unknown-unknown__stable",
                 "rust_windows_x86_64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-05-02__x86_64-pc-windows-msvc",
+                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable",
                 "rust_freebsd_x86_64__wasm32-unknown-unknown__stable",
                 "rust_freebsd_x86_64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-freebsd",
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable",
                 "rust_linux_x86_64__wasm32-unknown-unknown__stable",
                 "rust_linux_x86_64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-linux-gnu"
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu"
               ],
               "toolchain_labels": {
-                "rust_analyzer_1.78.0": "@rust_analyzer_1.78.0_tools//:rust_analyzer_toolchain",
+                "rust_analyzer_1.80.0": "@rust_analyzer_1.80.0_tools//:rust_analyzer_toolchain",
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
                 "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_darwin_aarch64__wasm32-wasi__stable": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-05-02__aarch64-apple-darwin": "@rustfmt_nightly-2024-05-02__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": "@rustfmt_nightly-2024-07-25__aarch64-apple-darwin_tools//:rustfmt_toolchain",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
                 "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_windows_aarch64__wasm32-wasi__stable": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-05-02__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-05-02__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_linux_aarch64__wasm32-wasi__stable": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-05-02__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-05-02__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
                 "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_darwin_x86_64__wasm32-wasi__stable": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-05-02__x86_64-apple-darwin": "@rustfmt_nightly-2024-05-02__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": "@rustfmt_nightly-2024-07-25__x86_64-apple-darwin_tools//:rustfmt_toolchain",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
                 "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_windows_x86_64__wasm32-wasi__stable": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-05-02__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-05-02__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
                 "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_freebsd_x86_64__wasm32-wasi__stable": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-05-02__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_linux_x86_64__wasm32-wasi__stable": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-05-02__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
               },
               "toolchain_types": {
-                "rust_analyzer_1.78.0": "@rules_rust//rust/rust_analyzer:toolchain_type",
+                "rust_analyzer_1.80.0": "@rules_rust//rust/rust_analyzer:toolchain_type",
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-05-02__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-05-02__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-05-02__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-05-02__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-05-02__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rules_rust//rust:toolchain",
                 "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_freebsd_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
               },
               "exec_compatible_with": {
-                "rust_analyzer_1.78.0": [],
+                "rust_analyzer_1.80.0": [],
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
@@ -2140,7 +2115,7 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
-                "rustfmt_nightly-2024-05-02__aarch64-apple-darwin": [
+                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
@@ -2156,7 +2131,7 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
-                "rustfmt_nightly-2024-05-02__aarch64-pc-windows-msvc": [
+                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
@@ -2172,7 +2147,7 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
-                "rustfmt_nightly-2024-05-02__aarch64-unknown-linux-gnu": [
+                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
@@ -2188,7 +2163,7 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
-                "rustfmt_nightly-2024-05-02__x86_64-apple-darwin": [
+                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
@@ -2204,7 +2179,7 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
-                "rustfmt_nightly-2024-05-02__x86_64-pc-windows-msvc": [
+                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
@@ -2220,7 +2195,7 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-freebsd": [
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
@@ -2236,13 +2211,13 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ],
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-linux-gnu": [
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ]
               },
               "target_compatible_with": {
-                "rust_analyzer_1.78.0": [],
+                "rust_analyzer_1.80.0": [],
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
@@ -2255,7 +2230,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-05-02__aarch64-apple-darwin": [],
+                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": [],
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
@@ -2268,7 +2243,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-05-02__aarch64-pc-windows-msvc": [],
+                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": [],
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
@@ -2281,7 +2256,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-05-02__aarch64-unknown-linux-gnu": [],
+                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": [],
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
@@ -2294,7 +2269,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-05-02__x86_64-apple-darwin": [],
+                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": [],
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
@@ -2307,7 +2282,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-05-02__x86_64-pc-windows-msvc": [],
+                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": [],
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
@@ -2320,7 +2295,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-freebsd": [],
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": [],
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
@@ -2333,7 +2308,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-05-02__x86_64-unknown-linux-gnu": []
+                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": []
               }
             }
           },
@@ -2346,8 +2321,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2371,8 +2346,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-apple-darwin",
               "iso_date": "",
-              "version": "1.78.0",
-              "rustfmt_version": "nightly/2024-05-02",
+              "version": "1.80.0",
+              "rustfmt_version": "nightly/2024-07-25",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2424,8 +2399,8 @@
     },
     "@@rules_rust~//rust/private:extensions.bzl%i": {
       "general": {
-        "bzlTransitiveDigest": "TIGGECOjgidPifIi97ieOsXMMF6PuCrCa/1tO4WwbXY=",
-        "usagesDigest": "/H7IcoHwXn42bCp+sLtEVBoZodYCPKf25DeNQcgSA5I=",
+        "bzlTransitiveDigest": "rMwKxVHbWVhLueuRGtDBlFYZ6DNmV++edWoHNGs8UNo=",
+        "usagesDigest": "I0P69+/LcY1EvjV4OiOpeGTaWbWXsltFZMwMHHYmqwE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2508,17 +2483,13 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fuchsia-cprng-0.1.1.bazel"
             }
           },
-          "cui__url-2.4.0": {
+          "rules_python": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/url/2.4.0/download"
-              ],
-              "strip_prefix": "url-2.4.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.url-2.4.0.bazel"
+              "sha256": "778aaeab3e6cfd56d681c89f5c10d7ad6bf8d2f1a72de9de55b23081b2d31618",
+              "strip_prefix": "rules_python-0.34.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.34.0/rules_python-0.34.0.tar.gz"
             }
           },
           "cui__ryu-1.0.14": {
@@ -3150,6 +3121,19 @@
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
             }
           },
+          "cui__num-conv-0.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-conv/0.1.0/download"
+              ],
+              "strip_prefix": "num-conv-0.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-conv-0.1.0.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__atty-0.2.14": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3540,17 +3524,17 @@
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustix-0.37.20.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-macro-support-0.2.91": {
+          "rules_rust_wasm_bindgen__wasm-bindgen-macro-support-0.2.92": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66",
+              "sha256": "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.92/download"
               ],
-              "strip_prefix": "wasm-bindgen-macro-support-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.91.bazel"
+              "strip_prefix": "wasm-bindgen-macro-support-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.92.bazel"
             }
           },
           "rules_rust_prost__fnv-1.0.7": {
@@ -3890,17 +3874,17 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.syn-2.0.32.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-externref-xform-0.2.91": {
+          "rules_rust_wasm_bindgen__wasm-bindgen-externref-xform-0.2.92": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "12b6ac5fca1d0992d2328147488169ea166bfe899c88f8ad06cf583f4c492fcf",
+              "sha256": "102582726b35a30d53157fbf8de3d0f0fed4c40c0c7951d69a034e9ef01da725",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-externref-xform/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-externref-xform/0.2.92/download"
               ],
-              "strip_prefix": "wasm-bindgen-externref-xform-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-externref-xform-0.2.91.bazel"
+              "strip_prefix": "wasm-bindgen-externref-xform-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-externref-xform-0.2.92.bazel"
             }
           },
           "rules_rust_prost__rustversion-1.0.12": {
@@ -4330,17 +4314,17 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.globwalk-0.8.1.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-interpreter-0.2.91": {
+          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-interpreter-0.2.92": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "682940195a701dbf887f20017418b8cac916a37b3f91ededec33226619e973c1",
+              "sha256": "9ea966593c8243a33eb4d643254eb97a69de04e89462f46cf6b4f506aae89b3a",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-wasm-interpreter/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-wasm-interpreter/0.2.92/download"
               ],
-              "strip_prefix": "wasm-bindgen-wasm-interpreter-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-interpreter-0.2.91.bazel"
+              "strip_prefix": "wasm-bindgen-wasm-interpreter-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-interpreter-0.2.92.bazel"
             }
           },
           "rules_rust_wasm_bindgen__ring-0.17.5": {
@@ -5105,6 +5089,19 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-complex-0.1.43.bazel"
             }
           },
+          "cui__once_cell-1.19.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.19.0/download"
+              ],
+              "strip_prefix": "once_cell-1.19.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.once_cell-1.19.0.bazel"
+            }
+          },
           "rules_rust_prost__pin-project-1.1.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -5287,17 +5284,17 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-0.2.91": {
+          "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f",
+              "sha256": "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/wasm-bindgen/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen/0.2.92/download"
               ],
-              "strip_prefix": "wasm-bindgen-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-0.2.91.bazel"
+              "strip_prefix": "wasm-bindgen-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-0.2.92.bazel"
             }
           },
           "rules_rust_prost__winapi-i686-pc-windows-gnu-0.4.0": {
@@ -5731,7 +5728,7 @@
               "integrity": "sha256-iFZe4JEQqZ54KZiX+/7VA7mqAwZThu6MGBl/yvIotQE=",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bindgen-cli/0.69.1/download"
+                "https://static.crates.io/crates/bindgen-cli/bindgen-cli-0.69.1.crate"
               ],
               "strip_prefix": "bindgen-cli-0.69.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty:BUILD.bindgen-cli.bazel"
@@ -5826,6 +5823,19 @@
               ],
               "strip_prefix": "rand-0.8.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "cui__time-0.3.36": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time/0.3.36/download"
+              ],
+              "strip_prefix": "time-0.3.36",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-0.3.36.bazel"
             }
           },
           "cui__errno-0.3.1": {
@@ -6034,19 +6044,6 @@
               ],
               "strip_prefix": "aho-corasick-1.0.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
-            }
-          },
-          "cui__time-0.3.30": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/time/0.3.30/download"
-              ],
-              "strip_prefix": "time-0.3.30",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-0.3.30.bazel"
             }
           },
           "rules_rust_proto__grpc-0.6.2": {
@@ -6740,19 +6737,6 @@
               ],
               "strip_prefix": "sync_wrapper-0.1.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-0.1.2.bazel"
-            }
-          },
-          "cui__idna-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/idna/0.4.0/download"
-              ],
-              "strip_prefix": "idna-0.4.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.idna-0.4.0.bazel"
             }
           },
           "cui__wasm-bindgen-macro-support-0.2.87": {
@@ -7483,17 +7467,17 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.void-1.0.2.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.91": {
+          "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "806a045c4ec4ef7c3ad86dc27bcb641b84d9eeb3846200f56d7ab0885241d654",
+              "sha256": "ca821da8c1ae6c87c5e94493939a206daa8587caff227c6032e0061a3d80817f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-cli-support/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-cli-support/0.2.92/download"
               ],
-              "strip_prefix": "wasm-bindgen-cli-support-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-cli-support-0.2.91.bazel"
+              "strip_prefix": "wasm-bindgen-cli-support-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-cli-support-0.2.92.bazel"
             }
           },
           "rules_rust_prost__regex-syntax-0.7.2": {
@@ -7542,7 +7526,7 @@
               "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/heck/0.4.1/download"
+                "https://static.crates.io/crates/heck/heck-0.4.1.crate"
               ],
               "strip_prefix": "heck-0.4.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.heck-0.4.1.bazel"
@@ -7644,7 +7628,7 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "sha256": "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a",
-              "url": "https://crates.io/api/v1/crates/tinyjson/2.5.1/download",
+              "url": "https://static.crates.io/crates/tinyjson/tinyjson-2.5.1.crate",
               "strip_prefix": "tinyjson-2.5.1",
               "type": "tar.gz",
               "build_file": "@@rules_rust~//util/process_wrapper:BUILD.tinyjson.bazel"
@@ -7773,17 +7757,17 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.protobuf-2.8.2.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.91": {
+          "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838",
+              "sha256": "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.92/download"
               ],
-              "strip_prefix": "wasm-bindgen-shared-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.91.bazel"
+              "strip_prefix": "wasm-bindgen-shared-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.92.bazel"
             }
           },
           "rules_rust_wasm_bindgen__httpdate-1.0.2": {
@@ -8027,6 +8011,19 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
             }
           },
+          "cui__url-2.5.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/url/2.5.2/download"
+              ],
+              "strip_prefix": "url-2.5.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.url-2.5.2.bazel"
+            }
+          },
           "rules_rust_bindgen__windows_i686_gnu-0.48.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -8247,17 +8244,17 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-backend-0.2.91": {
+          "rules_rust_wasm_bindgen__wasm-bindgen-backend-0.2.92": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b",
+              "sha256": "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.92/download"
               ],
-              "strip_prefix": "wasm-bindgen-backend-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.91.bazel"
+              "strip_prefix": "wasm-bindgen-backend-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.92.bazel"
             }
           },
           "cui__encoding_rs-0.8.33": {
@@ -8611,17 +8608,17 @@
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-conventions-0.2.91": {
+          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-conventions-0.2.92": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "4e6b653f6820409609bda0f176e6949302307af7a7b9479cd4d4b1bdc31eb9cd",
+              "sha256": "8c04e3607b810e76768260db3a5f2e8beb477cb089ef8726da85c8eb9bd3b575",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-wasm-conventions/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-wasm-conventions/0.2.92/download"
               ],
-              "strip_prefix": "wasm-bindgen-wasm-conventions-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-conventions-0.2.91.bazel"
+              "strip_prefix": "wasm-bindgen-wasm-conventions-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-conventions-0.2.92.bazel"
             }
           },
           "cui__valuable-0.1.0": {
@@ -8901,12 +8898,12 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "80b674e1bda34888e132276ba600676cea158bdcd289bb7da5c25885f1a3a535",
+              "sha256": "08f61e21873f51e3059a8c7c3eef81ede7513d161cfc60751c7b2ffa6ed28270",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-cli/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-cli/wasm-bindgen-cli-0.2.92.crate"
               ],
               "type": "tar.gz",
-              "strip_prefix": "wasm-bindgen-cli-0.2.91",
+              "strip_prefix": "wasm-bindgen-cli-0.2.92",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty:BUILD.wasm-bindgen-cli.bazel",
               "patch_args": [
                 "-p1"
@@ -9148,6 +9145,19 @@
               ],
               "strip_prefix": "winapi-0.3.9",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-threads-xform-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2d5add359b7f7d09a55299a9d29be54414264f2b8cf84f8c8fda5be9269b5dd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-threads-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-threads-xform-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-threads-xform-0.2.92.bazel"
             }
           },
           "rules_rust_wasm_bindgen__core-foundation-sys-0.8.4": {
@@ -10007,19 +10017,6 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf-0.11.2.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-threads-xform-0.2.91": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "90a2e577034352f9aa9352730fcf2562c68957f2e9b9ee70ab6379510e49e2fe",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-threads-xform/0.2.91/download"
-              ],
-              "strip_prefix": "wasm-bindgen-threads-xform-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-threads-xform-0.2.91.bazel"
-            }
-          },
           "rules_rust_wasm_bindgen__winapi-0.3.9": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10468,19 +10465,6 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.semver-1.0.17.bazel"
             }
           },
-          "cui__once_cell-1.18.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/once_cell/1.18.0/download"
-              ],
-              "strip_prefix": "once_cell-1.18.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
-            }
-          },
           "rules_rust_wasm_bindgen__wasmparser-0.80.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10793,6 +10777,19 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-packetline-0.16.7.bazel"
             }
           },
+          "cui__time-macros-0.2.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time-macros/0.2.18/download"
+              ],
+              "strip_prefix": "time-macros-0.2.18",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-macros-0.2.18.bazel"
+            }
+          },
           "cui__time-core-0.1.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10817,19 +10814,6 @@
               ],
               "strip_prefix": "itertools-0.12.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.itertools-0.12.0.bazel"
-            }
-          },
-          "cui__time-macros-0.2.15": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/time-macros/0.2.15/download"
-              ],
-              "strip_prefix": "time-macros-0.2.15",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-macros-0.2.15.bazel"
             }
           },
           "rules_rust_prost__try-lock-0.2.4": {
@@ -10936,19 +10920,6 @@
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.libc-0.2.146.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-multi-value-xform-0.2.91": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d1e019acde479e2f090fb7f14a51fa0077ec3a7bb12a56e0e888a82be7b5bd3f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-multi-value-xform/0.2.91/download"
-              ],
-              "strip_prefix": "wasm-bindgen-multi-value-xform-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-multi-value-xform-0.2.91.bazel"
-            }
-          },
           "rules_rust_wasm_bindgen__itertools-0.10.5": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10986,6 +10957,19 @@
               ],
               "strip_prefix": "futures-0.1.31",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.futures-0.1.31.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-multi-value-xform-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3498e4799f43523d780ceff498f04d882a8dbc9719c28020034822e5952f32a4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-multi-value-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-multi-value-xform-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-multi-value-xform-0.2.92.bazel"
             }
           },
           "rules_rust_proto__crossbeam-deque-0.7.4": {
@@ -11365,17 +11349,17 @@
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.syn-1.0.109.bazel"
             }
           },
-          "cui__percent-encoding-2.3.0": {
+          "cui__percent-encoding-2.3.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
+              "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/percent-encoding/2.3.0/download"
+                "https://static.crates.io/crates/percent-encoding/2.3.1/download"
               ],
-              "strip_prefix": "percent-encoding-2.3.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.percent-encoding-2.3.0.bazel"
+              "strip_prefix": "percent-encoding-2.3.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.percent-encoding-2.3.1.bazel"
             }
           },
           "rules_rust_wasm_bindgen__hashbrown-0.14.0": {
@@ -11506,6 +11490,19 @@
               ],
               "strip_prefix": "tokio-tcp-0.1.4",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-tcp-0.1.4.bazel"
+            }
+          },
+          "cui__idna-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/idna/0.5.0/download"
+              ],
+              "strip_prefix": "idna-0.5.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.idna-0.5.0.bazel"
             }
           },
           "rules_rust_bindgen__yansi-term-0.1.2": {
@@ -12020,6 +12017,19 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sharded-slab-0.1.7.bazel"
             }
           },
+          "cui__form_urlencoded-1.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/form_urlencoded/1.2.1/download"
+              ],
+              "strip_prefix": "form_urlencoded-1.2.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.form_urlencoded-1.2.1.bazel"
+            }
+          },
           "rrra__itoa-1.0.8": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -12031,19 +12041,6 @@
               ],
               "strip_prefix": "itoa-1.0.8",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
-            }
-          },
-          "cui__form_urlencoded-1.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/form_urlencoded/1.2.0/download"
-              ],
-              "strip_prefix": "form_urlencoded-1.2.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.form_urlencoded-1.2.0.bazel"
             }
           },
           "cui__gix-commitgraph-0.21.0": {
@@ -12488,19 +12485,6 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.httpbis-0.7.0.bazel"
             }
           },
-          "rules_rust_wasm_bindgen__wasm-bindgen-macro-0.2.91": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.91/download"
-              ],
-              "strip_prefix": "wasm-bindgen-macro-0.2.91",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.91.bazel"
-            }
-          },
           "cui__gix-revision-0.22.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -12512,6 +12496,19 @@
               ],
               "strip_prefix": "gix-revision-0.22.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-revision-0.22.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-macro-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.92.bazel"
             }
           },
           "cui__camino-1.1.6": {
@@ -12701,6 +12698,7 @@
             "cui__indoc-2.0.4",
             "cui__itertools-0.12.0",
             "cui__normpath-1.1.1",
+            "cui__once_cell-1.19.0",
             "cui__pathdiff-0.2.1",
             "cui__regex-1.10.2",
             "cui__semver-1.0.20",
@@ -12715,6 +12713,7 @@
             "cui__toml-0.8.10",
             "cui__tracing-0.1.40",
             "cui__tracing-subscriber-0.3.17",
+            "cui__url-2.5.2",
             "cui__maplit-1.0.2",
             "cui__spectral-0.6.0",
             "cargo_bazel.buildifier-darwin-amd64",
@@ -12764,9 +12763,9 @@
             "rules_rust_wasm_bindgen__serde_json-1.0.102",
             "rules_rust_wasm_bindgen__ureq-2.8.0",
             "rules_rust_wasm_bindgen__walrus-0.20.3",
-            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.91",
-            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.91",
-            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.91",
+            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92",
+            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92",
+            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92",
             "rules_rust_wasm_bindgen__assert_cmd-1.0.8",
             "rules_rust_wasm_bindgen__diff-0.1.13",
             "rules_rust_wasm_bindgen__predicates-1.0.8",
@@ -12778,7 +12777,8 @@
             "generated_inputs_in_external_repo",
             "libc",
             "rules_rust_toolchain_test_target_json",
-            "com_google_googleapis"
+            "com_google_googleapis",
+            "rules_python"
           ],
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",
@@ -12867,6 +12867,11 @@
           ],
           [
             "rules_rust~",
+            "cui__once_cell-1.19.0",
+            "rules_rust~~i~cui__once_cell-1.19.0"
+          ],
+          [
+            "rules_rust~",
             "cui__pathdiff-0.2.1",
             "rules_rust~~i~cui__pathdiff-0.2.1"
           ],
@@ -12939,6 +12944,11 @@
             "rules_rust~",
             "cui__tracing-subscriber-0.3.17",
             "rules_rust~~i~cui__tracing-subscriber-0.3.17"
+          ],
+          [
+            "rules_rust~",
+            "cui__url-2.5.2",
+            "rules_rust~~i~cui__url-2.5.2"
           ],
           [
             "rules_rust~",
@@ -13162,18 +13172,18 @@
           ],
           [
             "rules_rust~",
-            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.91",
-            "rules_rust~~i~rules_rust_wasm_bindgen__wasm-bindgen-0.2.91"
+            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92",
+            "rules_rust~~i~rules_rust_wasm_bindgen__wasm-bindgen-0.2.92"
           ],
           [
             "rules_rust~",
-            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.91",
-            "rules_rust~~i~rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.91"
+            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92",
+            "rules_rust~~i~rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92"
           ],
           [
             "rules_rust~",
-            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.91",
-            "rules_rust~~i~rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.91"
+            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92",
+            "rules_rust~~i~rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92"
           ],
           [
             "rules_rust~",

--- a/prost/BUILD
+++ b/prost/BUILD
@@ -21,7 +21,6 @@ rust_prost_toolchain(
     prost_plugin = "@crates//:protoc-gen-prost__protoc-gen-prost",
     prost_runtime = ":prost_runtime",
     prost_types = "@crates//:prost-types",
-    proto_compiler = "@protobuf//:protoc",
     tonic_plugin = "@crates//:protoc-gen-tonic__protoc-gen-tonic",
     tonic_runtime = ":tonic_runtime",
 )

--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -223,10 +223,10 @@ impl<Client: BazelClient> BazelContext<Client> {
     fn url_for_doc(doc: &Doc) -> LspUrl {
         let url = match &doc.item {
             DocItem::Module(_) => Url::parse("starlark:/native/builtins.bzl").unwrap(),
-            DocItem::Object(_) => {
+            DocItem::Type(_) => {
                 Url::parse(&format!("starlark:/native/builtins/{}.bzl", doc.id.name)).unwrap()
             }
-            DocItem::Function(_) | DocItem::Property(_) => {
+            DocItem::Member(_) => {
                 Url::parse("starlark:/native/builtins.bzl").unwrap()
             }
         };
@@ -612,6 +612,7 @@ impl<Client: BazelClient> BazelContext<Client> {
 
         let members: SmallMap<_, _> = builtin::build_language_to_doc_members(&language)
             .chain(builtin::builtins_to_doc_members(&builtins, file_type))
+            .map(|(name, member)| (name, DocItem::Member(member)))
             .collect();
 
         Ok(DocModule {

--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -226,9 +226,7 @@ impl<Client: BazelClient> BazelContext<Client> {
             DocItem::Type(_) => {
                 Url::parse(&format!("starlark:/native/builtins/{}.bzl", doc.id.name)).unwrap()
             }
-            DocItem::Member(_) => {
-                Url::parse("starlark:/native/builtins.bzl").unwrap()
-            }
+            DocItem::Member(_) => Url::parse("starlark:/native/builtins.bzl").unwrap(),
         };
         LspUrl::try_from(url).unwrap()
     }


### PR DESCRIPTION
This updates the upstream starlark-rust repo. This involves updating rust, and therefore rules_rust. This also involves a few changes to fix things that broke as a result.