### PR TITLE
build: update rules_rust 0.49.3 -> 0.54.1

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,6 +13,7 @@ rust_binary(
         "//src/builtin:builtin_proto_rust",
         "@crates//:anyhow",
         "@crates//:clap",
+        "@crates//:prost",
         "@crates//:either",
         "@crates//:hex",
         "@crates//:lsp-types",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-bazel_dep(name = "rules_rust", version = "0.49.3")
+bazel_dep(name = "rules_rust", version = "0.54.1")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -102,8 +102,8 @@
     "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel": "26114f0c0b5e93018c0c066d6673f1a2c3737c7e90af95eff30cfee38d0bbac7",
     "https://bcr.bazel.build/modules/rules_python/0.22.1/source.json": "57226905e783bae7c37c2dd662be078728e48fa28ee4324a7eabcafb5a43d014",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
-    "https://bcr.bazel.build/modules/rules_rust/0.49.3/MODULE.bazel": "7c747ca20606b61fdb3c99c537a97a7cc89ac48482c0f25b3e70787297b0ec46",
-    "https://bcr.bazel.build/modules/rules_rust/0.49.3/source.json": "0f4627d0ed4cd0d5af58f0162f87dcdf38fe4578e5308a3d7dca4c68cb13e323",
+    "https://bcr.bazel.build/modules/rules_rust/0.54.1/MODULE.bazel": "388547bb0cd6a751437bb15c94c6725226f50100eec576e4354c3a8b48c754fb",
+    "https://bcr.bazel.build/modules/rules_rust/0.54.1/source.json": "9c5481b1abe4943457e6b2a475592d2e504b6b4355df603f24f64cde0a7f0f2d",
     "https://bcr.bazel.build/modules/stardoc/0.5.0/MODULE.bazel": "f9f1f46ba8d9c3362648eea571c6f9100680efc44913618811b58cc9c02cd678",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
@@ -810,1612 +810,62 @@
         ]
       }
     },
-    "@@rules_rust~//rust:extensions.bzl%rust": {
-      "general": {
-        "bzlTransitiveDigest": "1o/b7Y8jEnrOScZ+yQtYRKKvtsG0oN4i7cwaXawLv3E=",
-        "usagesDigest": "IdLhWGRQjv892iEmVr/wsHsLM2wQUBlUXFvr210uCXY=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "rust_analyzer_1.80.0_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_analyzer_toolchain_tools_repository",
-            "attributes": {
-              "version": "1.80.0",
-              "iso_date": "",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_windows_x86_64__wasm32-wasi__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-pc-windows-msvc",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_darwin_aarch64__wasm32-wasi__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-apple-darwin",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_darwin_x86_64__wasm32-wasi__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-apple-darwin",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-07-25__x86_64-apple-darwin_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-unknown-freebsd",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_freebsd_x86_64__wasm32-wasi__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:freebsd"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
-              ]
-            }
-          },
-          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-unknown-linux-gnu",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "aarch64-unknown-linux-gnu",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:linux"
-              ]
-            }
-          },
-          "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rust_windows_x86_64": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_set_repository",
-            "attributes": {
-              "toolchains": [
-                "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable//:toolchain",
-                "@rust_windows_x86_64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_windows_x86_64__wasm32-wasi__stable//:toolchain"
-              ]
-            }
-          },
-          "rust_linux_aarch64__wasm32-unknown-unknown__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
-              ]
-            }
-          },
-          "rust_windows_aarch64__wasm32-wasi__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-pc-windows-msvc",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-unknown-linux-gnu",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "x86_64-unknown-linux-gnu",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_analyzer_1.80.0": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_analyzer_1.80.0_tools//:rust_analyzer_toolchain",
-              "toolchain_type": "@rules_rust//rust/rust_analyzer:toolchain_type",
-              "exec_compatible_with": [],
-              "target_compatible_with": []
-            }
-          },
-          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-pc-windows-msvc",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "aarch64-pc-windows-msvc",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_windows_aarch64": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_set_repository",
-            "attributes": {
-              "toolchains": [
-                "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable//:toolchain",
-                "@rust_windows_aarch64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_windows_aarch64__wasm32-wasi__stable//:toolchain"
-              ]
-            }
-          },
-          "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rust_linux_x86_64__wasm32-unknown-unknown__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
-              ]
-            }
-          },
-          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-pc-windows-msvc",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "x86_64-pc-windows-msvc",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-07-25",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "x86_64-unknown-freebsd"
-            }
-          },
-          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-unknown-freebsd",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "x86_64-unknown-freebsd",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_darwin_x86_64__wasm32-unknown-unknown__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
-              ]
-            }
-          },
-          "rust_darwin_aarch64__wasm32-unknown-unknown__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
-              ]
-            }
-          },
-          "rust_darwin_aarch64__aarch64-apple-darwin__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:osx"
-              ]
-            }
-          },
-          "rust_windows_x86_64__wasm32-wasi__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
-              ]
-            }
-          },
-          "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-07-25",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "aarch64-unknown-linux-gnu"
-            }
-          },
-          "rust_darwin_x86_64": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_set_repository",
-            "attributes": {
-              "toolchains": [
-                "@rust_darwin_x86_64__x86_64-apple-darwin__stable//:toolchain",
-                "@rust_darwin_x86_64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_darwin_x86_64__wasm32-wasi__stable//:toolchain"
-              ]
-            }
-          },
-          "rust_windows_aarch64__wasm32-wasi__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
-              ]
-            }
-          },
-          "rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-apple-darwin",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-apple-darwin",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_windows_x86_64__wasm32-unknown-unknown__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-pc-windows-msvc",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_linux_aarch64__wasm32-wasi__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
-              ]
-            }
-          },
-          "rust_darwin_aarch64": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_set_repository",
-            "attributes": {
-              "toolchains": [
-                "@rust_darwin_aarch64__aarch64-apple-darwin__stable//:toolchain",
-                "@rust_darwin_aarch64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_darwin_aarch64__wasm32-wasi__stable//:toolchain"
-              ]
-            }
-          },
-          "rustfmt_nightly-2024-07-25__aarch64-apple-darwin_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-07-25",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "aarch64-apple-darwin"
-            }
-          },
-          "rust_darwin_x86_64__x86_64-apple-darwin__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:osx"
-              ]
-            }
-          },
-          "rust_linux_x86_64__wasm32-unknown-unknown__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-unknown-linux-gnu",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_freebsd_x86_64__wasm32-wasi__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-unknown-freebsd",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_darwin_x86_64__wasm32-wasi__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
-              ]
-            }
-          },
-          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:freebsd"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
-              ]
-            }
-          },
-          "rust_freebsd_x86_64": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_set_repository",
-            "attributes": {
-              "toolchains": [
-                "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable//:toolchain",
-                "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_freebsd_x86_64__wasm32-wasi__stable//:toolchain"
-              ]
-            }
-          },
-          "rust_linux_x86_64__wasm32-wasi__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-unknown-linux-gnu",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_windows_x86_64__wasm32-unknown-unknown__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
-              ]
-            }
-          },
-          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:linux"
-              ]
-            }
-          },
-          "rust_linux_x86_64": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_set_repository",
-            "attributes": {
-              "toolchains": [
-                "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable//:toolchain",
-                "@rust_linux_x86_64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_linux_x86_64__wasm32-wasi__stable//:toolchain"
-              ]
-            }
-          },
-          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:windows"
-              ]
-            }
-          },
-          "rust_linux_x86_64__wasm32-wasi__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
-              ]
-            }
-          },
-          "rust_windows_aarch64__wasm32-unknown-unknown__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-pc-windows-msvc",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_darwin_aarch64__aarch64-apple-darwin__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-apple-darwin",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "aarch64-apple-darwin",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_linux_aarch64__wasm32-wasi__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-unknown-linux-gnu",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-07-25",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "aarch64-pc-windows-msvc"
-            }
-          },
-          "rust_windows_aarch64__wasm32-unknown-unknown__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
-              ]
-            }
-          },
-          "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-07-25__aarch64-apple-darwin_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rust_linux_aarch64": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_set_repository",
-            "attributes": {
-              "toolchains": [
-                "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain",
-                "@rust_linux_aarch64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_linux_aarch64__wasm32-wasi__stable//:toolchain"
-              ]
-            }
-          },
-          "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-07-25",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "x86_64-unknown-linux-gnu"
-            }
-          },
-          "rust_darwin_aarch64__wasm32-wasi__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
-              ]
-            }
-          },
-          "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-07-25",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "x86_64-pc-windows-msvc"
-            }
-          },
-          "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:freebsd"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:windows"
-              ]
-            }
-          },
-          "rustfmt_nightly-2024-07-25__x86_64-apple-darwin_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-07-25",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": {},
-              "exec_triple": "x86_64-apple-darwin"
-            }
-          },
-          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:freebsd"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:freebsd"
-              ]
-            }
-          },
-          "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rust_toolchains": {
-            "bzlFile": "@@rules_rust~//rust/private:repository_utils.bzl",
-            "ruleClassName": "toolchain_repository_hub",
-            "attributes": {
-              "toolchain_names": [
-                "rust_analyzer_1.80.0",
-                "rust_darwin_aarch64__aarch64-apple-darwin__stable",
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable",
-                "rust_darwin_aarch64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin",
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable",
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable",
-                "rust_windows_aarch64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc",
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable",
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable",
-                "rust_linux_aarch64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu",
-                "rust_darwin_x86_64__x86_64-apple-darwin__stable",
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable",
-                "rust_darwin_x86_64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin",
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable",
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable",
-                "rust_windows_x86_64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc",
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable",
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable",
-                "rust_freebsd_x86_64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd",
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable",
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable",
-                "rust_linux_x86_64__wasm32-wasi__stable",
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu"
-              ],
-              "toolchain_labels": {
-                "rust_analyzer_1.80.0": "@rust_analyzer_1.80.0_tools//:rust_analyzer_toolchain",
-                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_darwin_aarch64__wasm32-wasi__stable": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": "@rustfmt_nightly-2024-07-25__aarch64-apple-darwin_tools//:rustfmt_toolchain",
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_windows_aarch64__wasm32-wasi__stable": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_linux_aarch64__wasm32-wasi__stable": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
-                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_darwin_x86_64__wasm32-wasi__stable": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": "@rustfmt_nightly-2024-07-25__x86_64-apple-darwin_tools//:rustfmt_toolchain",
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_windows_x86_64__wasm32-wasi__stable": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_linux_x86_64__wasm32-wasi__stable": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
-              },
-              "toolchain_types": {
-                "rust_analyzer_1.80.0": "@rules_rust//rust/rust_analyzer:toolchain_type",
-                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rules_rust//rust:toolchain",
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_darwin_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_windows_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_linux_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rules_rust//rust:toolchain",
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_darwin_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_windows_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rules_rust//rust:toolchain",
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_linux_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
-              },
-              "exec_compatible_with": {
-                "rust_analyzer_1.80.0": [],
-                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:osx"
-                ],
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:osx"
-                ],
-                "rust_darwin_aarch64__wasm32-wasi__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:osx"
-                ],
-                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:osx"
-                ],
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:windows"
-                ],
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:windows"
-                ],
-                "rust_windows_aarch64__wasm32-wasi__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:windows"
-                ],
-                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:windows"
-                ],
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:linux"
-                ],
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:linux"
-                ],
-                "rust_linux_aarch64__wasm32-wasi__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:linux"
-                ],
-                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:linux"
-                ],
-                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:osx"
-                ],
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:osx"
-                ],
-                "rust_darwin_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:osx"
-                ],
-                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:osx"
-                ],
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:windows"
-                ],
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:windows"
-                ],
-                "rust_windows_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:windows"
-                ],
-                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:windows"
-                ],
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:freebsd"
-                ],
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:freebsd"
-                ],
-                "rust_freebsd_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:freebsd"
-                ],
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:freebsd"
-                ],
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:linux"
-                ],
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:linux"
-                ],
-                "rust_linux_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:linux"
-                ],
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:linux"
-                ]
-              },
-              "target_compatible_with": {
-                "rust_analyzer_1.80.0": [],
-                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:osx"
-                ],
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
-                ],
-                "rust_darwin_aarch64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
-                ],
-                "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": [],
-                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:windows"
-                ],
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
-                ],
-                "rust_windows_aarch64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
-                ],
-                "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": [],
-                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:linux"
-                ],
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
-                ],
-                "rust_linux_aarch64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
-                ],
-                "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": [],
-                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:osx"
-                ],
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
-                ],
-                "rust_darwin_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
-                ],
-                "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": [],
-                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:windows"
-                ],
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
-                ],
-                "rust_windows_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
-                ],
-                "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": [],
-                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:freebsd"
-                ],
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
-                ],
-                "rust_freebsd_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
-                ],
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": [],
-                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:linux"
-                ],
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
-                ],
-                "rust_linux_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
-                ],
-                "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": []
-              }
-            }
-          },
-          "rust_linux_aarch64__wasm32-unknown-unknown__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-unknown-linux-gnu",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_darwin_x86_64__x86_64-apple-darwin__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-apple-darwin",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "x86_64-apple-darwin",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "bazel_features~",
-            "bazel_features_globals",
-            "bazel_features~~version_extension~bazel_features_globals"
-          ],
-          [
-            "bazel_features~",
-            "bazel_features_version",
-            "bazel_features~~version_extension~bazel_features_version"
-          ],
-          [
-            "rules_rust~",
-            "bazel_features",
-            "bazel_features~"
-          ],
-          [
-            "rules_rust~",
-            "bazel_skylib",
-            "bazel_skylib~"
-          ],
-          [
-            "rules_rust~",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_rust~",
-            "rules_rust",
-            "rules_rust~"
-          ]
-        ]
-      }
-    },
     "@@rules_rust~//rust/private:extensions.bzl%i": {
       "general": {
-        "bzlTransitiveDigest": "rMwKxVHbWVhLueuRGtDBlFYZ6DNmV++edWoHNGs8UNo=",
-        "usagesDigest": "I0P69+/LcY1EvjV4OiOpeGTaWbWXsltFZMwMHHYmqwE=",
+        "bzlTransitiveDigest": "pxFxfbkRbAY+IapCvFgmU7bAkjU4Afu6e6FdSGkreuI=",
+        "usagesDigest": "IT42bd50EBCGtUmiKbiWO/sq3q1wKV3TDwEVgflxR2Q=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "rules_rust_prost__tracing-0.1.37": {
+          "cui__gix-path-0.10.11": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8",
+              "sha256": "ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/tracing/0.1.37/download"
+                "https://static.crates.io/crates/gix-path/0.10.11/download"
               ],
-              "strip_prefix": "tracing-0.1.37",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-0.1.37.bazel"
+              "strip_prefix": "gix-path-0.10.11",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-path-0.10.11.bazel"
+            }
+          },
+          "rules_rust_tinyjson": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a",
+              "url": "https://static.crates.io/crates/tinyjson/tinyjson-2.5.1.crate",
+              "strip_prefix": "tinyjson-2.5.1",
+              "type": "tar.gz",
+              "build_file": "@@rules_rust~//util/process_wrapper:BUILD.tinyjson.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bumpalo-3.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bumpalo/3.13.0/download"
+              ],
+              "strip_prefix": "bumpalo-3.13.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
+            }
+          },
+          "cui__pin-project-lite-0.2.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-lite/0.2.13/download"
+              ],
+              "strip_prefix": "pin-project-lite-0.2.13",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pin-project-lite-0.2.13.bazel"
             }
           },
           "rules_rust_wasm_bindgen__walrus-0.20.3": {
@@ -2444,6 +894,45 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
             }
           },
+          "cui__generic-array-0.14.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/generic-array/0.14.7/download"
+              ],
+              "strip_prefix": "generic-array-0.14.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.generic-array-0.14.7.bazel"
+            }
+          },
+          "cui__gix-hashtable-0.5.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-hashtable/0.5.2/download"
+              ],
+              "strip_prefix": "gix-hashtable-0.5.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-hashtable-0.5.2.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-codec-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-codec/0.1.2/download"
+              ],
+              "strip_prefix": "tokio-codec-0.1.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-codec-0.1.2.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__windows_x86_64_gnu-0.48.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -2455,6 +944,45 @@
               ],
               "strip_prefix": "windows_x86_64_gnu-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "rules_rust_prost__tonic-0.12.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tonic/0.12.1/download"
+              ],
+              "strip_prefix": "tonic-0.12.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tonic-0.12.1.bazel"
+            }
+          },
+          "cui__gix-diff-0.46.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "92c9afd80fff00f8b38b1c1928442feb4cd6d2232a6ed806b6b193151a3d336c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-diff/0.46.0/download"
+              ],
+              "strip_prefix": "gix-diff-0.46.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-diff-0.46.0.bazel"
+            }
+          },
+          "cui__gix-url-0.27.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fd280c5e84fb22e128ed2a053a0daeacb6379469be6a85e3d518a0636e160c89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-url/0.27.5/download"
+              ],
+              "strip_prefix": "gix-url-0.27.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-url-0.27.5.bazel"
             }
           },
           "cui__rustix-0.37.23": {
@@ -2470,17 +998,75 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
             }
           },
-          "cui__fuchsia-cprng-0.1.1": {
+          "rules_rust_wasm_bindgen__ureq-2.8.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba",
+              "sha256": "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/fuchsia-cprng/0.1.1/download"
+                "https://static.crates.io/crates/ureq/2.8.0/download"
               ],
-              "strip_prefix": "fuchsia-cprng-0.1.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fuchsia-cprng-0.1.1.bazel"
+              "strip_prefix": "ureq-2.8.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ureq-2.8.0.bazel"
+            }
+          },
+          "cui__parking_lot_core-0.9.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.9.9/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.9.9",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.parking_lot_core-0.9.9.bazel"
+            }
+          },
+          "rules_rust_prost__windows_aarch64_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rrra__quote-1.0.29": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.29/download"
+              ],
+              "strip_prefix": "quote-1.0.29",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.quote-1.0.29.bazel"
+            }
+          },
+          "rules_rust_proto__protobuf-2.8.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust~//proto/protobuf/3rdparty/patches:protobuf-2.8.2.patch"
+              ],
+              "sha256": "70731852eec72c56d11226c8a5f96ad5058a3dab73647ca5f7ee351e464f2571",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protobuf/2.8.2/download"
+              ],
+              "strip_prefix": "protobuf-2.8.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.protobuf-2.8.2.bazel"
             }
           },
           "rules_python": {
@@ -2490,6 +1076,84 @@
               "sha256": "778aaeab3e6cfd56d681c89f5c10d7ad6bf8d2f1a72de9de55b23081b2d31618",
               "strip_prefix": "rules_python-0.34.0",
               "url": "https://github.com/bazelbuild/rules_python/releases/download/0.34.0/rules_python-0.34.0.tar.gz"
+            }
+          },
+          "rules_rust_prost__hyper-util-0.1.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper-util/0.1.7/download"
+              ],
+              "strip_prefix": "hyper-util-0.1.7",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-util-0.1.7.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-shared-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.92.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-0.1.40": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing/0.1.40/download"
+              ],
+              "strip_prefix": "tracing-0.1.40",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-0.1.40.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__httpdate-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpdate/1.0.2/download"
+              ],
+              "strip_prefix": "httpdate-1.0.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.httpdate-1.0.2.bazel"
+            }
+          },
+          "rules_rust_prost__bytes-1.7.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bytes/1.7.1/download"
+              ],
+              "strip_prefix": "bytes-1.7.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.bytes-1.7.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__iana-time-zone-0.1.57": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
+              ],
+              "strip_prefix": "iana-time-zone-0.1.57",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
             }
           },
           "cui__ryu-1.0.14": {
@@ -2505,23 +1169,17 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
             }
           },
-          "rules_rust_prost__protoc-gen-prost-0.2.2": {
+          "rules_rust_bindgen__winapi-x86_64-pc-windows-gnu-0.4.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "patch_args": [
-                "-p1"
-              ],
-              "patches": [
-                "@@rules_rust~//proto/prost/private/3rdparty/patches:protoc-gen-prost.patch"
-              ],
-              "sha256": "a81e3a9bb429fec47008b209896f0b9ab99fbcbc1c3733b385d43fbfd64dd2ca",
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/protoc-gen-prost/0.2.2/download"
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
               ],
-              "strip_prefix": "protoc-gen-prost-0.2.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-prost-0.2.2.bazel"
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
             }
           },
           "rules_rust_bindgen__cfg-if-1.0.0": {
@@ -2537,32 +1195,6 @@
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
             }
           },
-          "rules_rust_prost__protoc-gen-tonic-0.2.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "725a07a704f9cf7a956b302c21d81b5516ed5ee6cfbbf827edb69beeaae6cc30",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/protoc-gen-tonic/0.2.2/download"
-              ],
-              "strip_prefix": "protoc-gen-tonic-0.2.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-tonic-0.2.2.bazel"
-            }
-          },
-          "cui__iana-time-zone-haiku-0.1.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download"
-              ],
-              "strip_prefix": "iana-time-zone-haiku-0.1.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.iana-time-zone-haiku-0.1.2.bazel"
-            }
-          },
           "cui__windows_x86_64_gnullvm-0.48.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -2576,30 +1208,43 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
             }
           },
-          "rules_rust_prost__percent-encoding-2.3.0": {
+          "rules_rust_prost__autocfg-1.3.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
+              "sha256": "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/percent-encoding/2.3.0/download"
+                "https://static.crates.io/crates/autocfg/1.3.0/download"
               ],
-              "strip_prefix": "percent-encoding-2.3.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.percent-encoding-2.3.0.bazel"
+              "strip_prefix": "autocfg-1.3.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.autocfg-1.3.0.bazel"
             }
           },
-          "cui__fastrand-2.0.1": {
+          "rules_rust_prost__percent-encoding-2.3.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5",
+              "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/fastrand/2.0.1/download"
+                "https://static.crates.io/crates/percent-encoding/2.3.1/download"
               ],
-              "strip_prefix": "fastrand-2.0.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fastrand-2.0.1.bazel"
+              "strip_prefix": "percent-encoding-2.3.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.percent-encoding-2.3.1.bazel"
+            }
+          },
+          "cui__gix-submodule-0.14.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "529d0af78cc2f372b3218f15eb1e3d1635a21c8937c12e2dd0b6fc80c2ca874b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-submodule/0.14.0/download"
+              ],
+              "strip_prefix": "gix-submodule-0.14.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-submodule-0.14.0.bazel"
             }
           },
           "cui__flate2-1.0.28": {
@@ -2615,17 +1260,30 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
             }
           },
-          "rules_rust_prost__cc-1.0.79": {
+          "rules_rust_prost__pin-utils-0.1.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
+              "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/cc/1.0.79/download"
+                "https://static.crates.io/crates/pin-utils/0.1.0/download"
               ],
-              "strip_prefix": "cc-1.0.79",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.cc-1.0.79.bazel"
+              "strip_prefix": "pin-utils-0.1.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-utils-0.1.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__libloading-0.8.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libloading/0.8.5/download"
+              ],
+              "strip_prefix": "libloading-0.8.5",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.libloading-0.8.5.bazel"
             }
           },
           "rrra__winapi-0.3.9": {
@@ -2641,6 +1299,32 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
             }
           },
+          "rules_rust_bindgen__prettyplease-0.2.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prettyplease/0.2.22/download"
+              ],
+              "strip_prefix": "prettyplease-0.2.22",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.prettyplease-0.2.22.bazel"
+            }
+          },
+          "cui__fnv-1.0.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
           "cui__windows-targets-0.48.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -2652,6 +1336,13 @@
               ],
               "strip_prefix": "windows-targets-0.48.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "rules_rust_toolchain_test_target_json": {
+            "bzlFile": "@@rules_rust~//test/unit/toolchain:toolchain_test_utils.bzl",
+            "ruleClassName": "rules_rust_toolchain_test_target_json_repository",
+            "attributes": {
+              "target_json": "@@rules_rust~//test/unit/toolchain:toolchain-test-triple.json"
             }
           },
           "rules_rust_wasm_bindgen__ppv-lite86-0.2.17": {
@@ -2719,43 +1410,95 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
             }
           },
-          "cui__libm-0.2.7": {
+          "rules_rust_bindgen__windows-sys-0.59.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4",
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/libm/0.2.7/download"
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
               ],
-              "strip_prefix": "libm-0.2.7",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.libm-0.2.7.bazel"
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
             }
           },
-          "cui__deranged-0.3.9": {
+          "rules_rust_proto__slab-0.3.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3",
+              "sha256": "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/deranged/0.3.9/download"
+                "https://static.crates.io/crates/slab/0.3.0/download"
               ],
-              "strip_prefix": "deranged-0.3.9",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.deranged-0.3.9.bazel"
+              "strip_prefix": "slab-0.3.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.slab-0.3.0.bazel"
             }
           },
-          "cui__gix-negotiate-0.8.0": {
+          "rules_rust_prost__rand_core-0.6.4": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "6f1697bf9911c6d1b8d709b9e6ef718cb5ea5821a1b7991520125a8134448004",
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-negotiate/0.8.0/download"
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
               ],
-              "strip_prefix": "gix-negotiate-0.8.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-negotiate-0.8.0.bazel"
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "rules_rust_prost__miniz_oxide-0.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.4/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.miniz_oxide-0.7.4.bazel"
+            }
+          },
+          "cui__gix-filter-0.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4121790ae140066e5b953becc72e7496278138d19239be2e63b5067b0843119e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-filter/0.13.0/download"
+              ],
+              "strip_prefix": "gix-filter-0.13.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-filter-0.13.0.bazel"
+            }
+          },
+          "rules_rust_prost__prost-derive-0.13.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-derive/0.13.1/download"
+              ],
+              "strip_prefix": "prost-derive-0.13.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-derive-0.13.1.bazel"
+            }
+          },
+          "cui__gix-utils-0.1.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "35192df7fd0fa112263bad8021e2df7167df4cc2a6e6d15892e1e55621d3d4dc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-utils/0.1.12/download"
+              ],
+              "strip_prefix": "gix-utils-0.1.12",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-utils-0.1.12.bazel"
             }
           },
           "rules_rust_proto__autocfg-1.1.0": {
@@ -2769,6 +1512,32 @@
               ],
               "strip_prefix": "autocfg-1.1.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-macros-2.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-macros/2.4.0/download"
+              ],
+              "strip_prefix": "tokio-macros-2.4.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-macros-2.4.0.bazel"
+            }
+          },
+          "cui__url-2.5.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/url/2.5.2/download"
+              ],
+              "strip_prefix": "url-2.5.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.url-2.5.2.bazel"
             }
           },
           "cui__io-lifetimes-1.0.11": {
@@ -2797,30 +1566,82 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cfg-if-0.1.10.bazel"
             }
           },
-          "rules_rust_prost__proc-macro2-1.0.60": {
+          "rules_rust_prost__smallvec-1.13.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406",
+              "sha256": "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/proc-macro2/1.0.60/download"
+                "https://static.crates.io/crates/smallvec/1.13.2/download"
               ],
-              "strip_prefix": "proc-macro2-1.0.60",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.proc-macro2-1.0.60.bazel"
+              "strip_prefix": "smallvec-1.13.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.smallvec-1.13.2.bazel"
             }
           },
-          "rules_rust_bindgen__clap_complete-4.3.1": {
+          "rules_rust_wasm_bindgen__alloc-no-stdlib-2.0.4": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "7f6b5c519bab3ea61843a7923d074b04245624bb84a64a8c150f5deb014e388b",
+              "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/clap_complete/4.3.1/download"
+                "https://static.crates.io/crates/alloc-no-stdlib/2.0.4/download"
               ],
-              "strip_prefix": "clap_complete-4.3.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_complete-4.3.1.bazel"
+              "strip_prefix": "alloc-no-stdlib-2.0.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.alloc-no-stdlib-2.0.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__env_logger-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.8.4/download"
+              ],
+              "strip_prefix": "env_logger-0.8.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.env_logger-0.8.4.bazel"
+            }
+          },
+          "cui__smol_str-0.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smol_str/0.2.0/download"
+              ],
+              "strip_prefix": "smol_str-0.2.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smol_str-0.2.0.bazel"
+            }
+          },
+          "cui__zerocopy-0.7.35": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-0.7.35",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.zerocopy-0.7.35.bazel"
+            }
+          },
+          "rules_rust_prost__itertools-0.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.13.0/download"
+              ],
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__time-core-0.1.1": {
@@ -2836,17 +1657,30 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.time-core-0.1.1.bazel"
             }
           },
-          "cui__num-0.1.42": {
+          "cui__log-0.4.19": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e",
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/num/0.1.42/download"
+                "https://static.crates.io/crates/log/0.4.19/download"
               ],
-              "strip_prefix": "num-0.1.42",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-0.1.42.bazel"
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "cui__cfg-expr-0.17.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d0890061c4d3223e7267f3bad2ec40b997d64faac1c2815a4a9d95018e2b9e9c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-expr/0.17.0/download"
+              ],
+              "strip_prefix": "cfg-expr-0.17.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cfg-expr-0.17.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__tiny_http-0.12.0": {
@@ -2862,30 +1696,69 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tiny_http-0.12.0.bazel"
             }
           },
-          "rules_rust_bindgen__windows-sys-0.48.0": {
+          "cui__gix-transport-0.42.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "sha256": "421dcccab01b41a15d97b226ad97a8f9262295044e34fbd37b10e493b0a6481f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+                "https://static.crates.io/crates/gix-transport/0.42.3/download"
               ],
-              "strip_prefix": "windows-sys-0.48.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+              "strip_prefix": "gix-transport-0.42.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-transport-0.42.3.bazel"
             }
           },
-          "rules_rust_bindgen__libc-0.2.146": {
+          "cui__pest-2.7.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b",
+              "sha256": "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/libc/0.2.146/download"
+                "https://static.crates.io/crates/pest/2.7.0/download"
               ],
-              "strip_prefix": "libc-0.2.146",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.libc-0.2.146.bazel"
+              "strip_prefix": "pest-2.7.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest-2.7.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__docopt-1.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/docopt/1.1.1/download"
+              ],
+              "strip_prefix": "docopt-1.1.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.docopt-1.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustc-demangle-0.1.23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-demangle/0.1.23/download"
+              ],
+              "strip_prefix": "rustc-demangle-0.1.23",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustc-demangle-0.1.23.bazel"
+            }
+          },
+          "rules_rust_prost__rand_chacha-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
             }
           },
           "rules_rust_wasm_bindgen__iana-time-zone-haiku-0.1.2": {
@@ -2901,6 +1774,19 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-haiku-0.1.2.bazel"
             }
           },
+          "cui__syn-1.0.109": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/1.0.109/download"
+              ],
+              "strip_prefix": "syn-1.0.109",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.syn-1.0.109.bazel"
+            }
+          },
           "rrra__memchr-2.5.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -2914,30 +1800,94 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
             }
           },
-          "cui__getrandom-0.2.10": {
+          "rules_rust_prost__futures-task-0.3.30": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
+              "sha256": "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/getrandom/0.2.10/download"
+                "https://static.crates.io/crates/futures-task/0.3.30/download"
               ],
-              "strip_prefix": "getrandom-0.2.10",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
+              "strip_prefix": "futures-task-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-task-0.3.30.bazel"
             }
           },
-          "rules_rust_prost__bitflags-1.3.2": {
+          "rules_rust_prost__tonic-build-0.12.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "sha256": "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/bitflags/1.3.2/download"
+                "https://static.crates.io/crates/tonic-build/0.12.1/download"
               ],
-              "strip_prefix": "bitflags-1.3.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+              "strip_prefix": "tonic-build-0.12.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tonic-build-0.12.1.bazel"
+            }
+          },
+          "cui__pathdiff-0.2.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pathdiff/0.2.2/download"
+              ],
+              "strip_prefix": "pathdiff-0.2.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pathdiff-0.2.2.bazel"
+            }
+          },
+          "cargo_bazel.buildifier-linux-amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-amd64"
+              ],
+              "integrity": "sha256-VHTMUSinToBng9VAgfWBZixL6K5lAi9VfpKB7V3IgAk=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "rules_rust_prost__httparse-1.9.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httparse/1.9.4/download"
+              ],
+              "strip_prefix": "httparse-1.9.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.httparse-1.9.4.bazel"
+            }
+          },
+          "rules_rust_prost__zerocopy-0.7.35": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-0.7.35",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.zerocopy-0.7.35.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__either-1.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.8.1/download"
+              ],
+              "strip_prefix": "either-1.8.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.either-1.8.1.bazel"
             }
           },
           "cui__sha1_smol-1.0.0": {
@@ -2953,16 +1903,42 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
             }
           },
+          "rules_rust_wasm_bindgen__crc32fast-1.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
+              ],
+              "strip_prefix": "crc32fast-1.3.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
+            }
+          },
           "cargo_bazel.buildifier-darwin-amd64": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v7.1.1/buildifier-darwin-amd64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-amd64"
               ],
-              "integrity": "sha256-d0YNlXr3oCi7GK223EP6ZLbgAGTkc+rINoq4pwOzp0M=",
+              "integrity": "sha256-N1+CMQPQFiCq7CCgwpxsvKmfT9ByWuMLk2VcZwT0TXE=",
               "downloaded_file_path": "buildifier",
               "executable": true
+            }
+          },
+          "rules_rust_prost__http-body-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http-body/1.0.1/download"
+              ],
+              "strip_prefix": "http-body-1.0.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-body-1.0.1.bazel"
             }
           },
           "rules_rust_proto__iovec-0.1.4": {
@@ -2991,19 +1967,6 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.byteorder-1.4.3.bazel"
             }
           },
-          "cui__chrono-0.4.26": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/chrono/0.4.26/download"
-              ],
-              "strip_prefix": "chrono-0.4.26",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
-            }
-          },
           "rules_rust_proto__redox_syscall-0.1.57": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3017,17 +1980,30 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.redox_syscall-0.1.57.bazel"
             }
           },
-          "rules_rust_bindgen__proc-macro2-1.0.60": {
+          "rules_rust_prost__async-stream-impl-0.3.5": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406",
+              "sha256": "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/proc-macro2/1.0.60/download"
+                "https://static.crates.io/crates/async-stream-impl/0.3.5/download"
               ],
-              "strip_prefix": "proc-macro2-1.0.60",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.60.bazel"
+              "strip_prefix": "async-stream-impl-0.3.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.async-stream-impl-0.3.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-backend-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-backend-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.92.bazel"
             }
           },
           "rrra__windows_i686_msvc-0.48.0": {
@@ -3043,6 +2019,32 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
             }
           },
+          "cui__encoding_rs-0.8.33": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/encoding_rs/0.8.33/download"
+              ],
+              "strip_prefix": "encoding_rs-0.8.33",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.encoding_rs-0.8.33.bazel"
+            }
+          },
+          "rules_rust_proto__hermit-abi-0.2.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.2.6/download"
+              ],
+              "strip_prefix": "hermit-abi-0.2.6",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.hermit-abi-0.2.6.bazel"
+            }
+          },
           "cui__overload-0.1.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3056,17 +2058,30 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.overload-0.1.1.bazel"
             }
           },
-          "rules_rust_bindgen__clap_derive-4.3.2": {
+          "rules_rust_prost__want-0.3.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
+              "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/clap_derive/4.3.2/download"
+                "https://static.crates.io/crates/want/0.3.1/download"
               ],
-              "strip_prefix": "clap_derive-4.3.2",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
+              "strip_prefix": "want-0.3.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.want-0.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__h2-0.4.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/h2/0.4.6/download"
+              ],
+              "strip_prefix": "h2-0.4.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.h2-0.4.6.bazel"
             }
           },
           "cui__anstream-0.3.2": {
@@ -3095,43 +2110,108 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
             }
           },
-          "rules_rust_prost__smallvec-1.10.0": {
+          "rules_rust_prost__hyper-timeout-0.5.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0",
+              "sha256": "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/smallvec/1.10.0/download"
+                "https://static.crates.io/crates/hyper-timeout/0.5.1/download"
               ],
-              "strip_prefix": "smallvec-1.10.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.smallvec-1.10.0.bazel"
+              "strip_prefix": "hyper-timeout-0.5.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-timeout-0.5.1.bazel"
             }
           },
-          "rules_rust_prost__windows_x86_64_gnu-0.48.0": {
+          "rules_rust_proto__tokio-timer-0.2.13": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "sha256": "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+                "https://static.crates.io/crates/tokio-timer/0.2.13/download"
               ],
-              "strip_prefix": "windows_x86_64_gnu-0.48.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+              "strip_prefix": "tokio-timer-0.2.13",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.2.13.bazel"
             }
           },
-          "cui__num-conv-0.1.0": {
+          "cui__rustix-0.38.37": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9",
+              "sha256": "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/num-conv/0.1.0/download"
+                "https://static.crates.io/crates/rustix/0.38.37/download"
               ],
-              "strip_prefix": "num-conv-0.1.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-conv-0.1.0.bazel"
+              "strip_prefix": "rustix-0.38.37",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustix-0.38.37.bazel"
+            }
+          },
+          "cui__itoa-1.0.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "cui__once_cell-1.20.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.20.2/download"
+              ],
+              "strip_prefix": "once_cell-1.20.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.once_cell-1.20.2.bazel"
+            }
+          },
+          "rules_rust_proto__cloudabi-0.0.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cloudabi/0.0.3/download"
+              ],
+              "strip_prefix": "cloudabi-0.0.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cloudabi-0.0.3.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-automata-0.4.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.7/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.7",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-automata-0.4.7.bazel"
+            }
+          },
+          "cui__gix-attributes-0.22.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ebccbf25aa4a973dd352564a9000af69edca90623e8a16dad9cbc03713131311",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-attributes/0.22.5/download"
+              ],
+              "strip_prefix": "gix-attributes-0.22.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-attributes-0.22.5.bazel"
             }
           },
           "rules_rust_wasm_bindgen__atty-0.2.14": {
@@ -3145,6 +2225,32 @@
               ],
               "strip_prefix": "atty-0.2.14",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.atty-0.2.14.bazel"
+            }
+          },
+          "rules_rust_prost__protoc-gen-prost-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "77eb17a7657a703f30cb9b7ba4d981e4037b8af2d819ab0077514b0bef537406",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protoc-gen-prost/0.4.0/download"
+              ],
+              "strip_prefix": "protoc-gen-prost-0.4.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-prost-0.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-1.39.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio/1.39.3/download"
+              ],
+              "strip_prefix": "tokio-1.39.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-1.39.3.bazel"
             }
           },
           "cui__walkdir-2.3.3": {
@@ -3173,6 +2279,19 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
             }
           },
+          "cui__static_assertions-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/static_assertions/1.1.0/download"
+              ],
+              "strip_prefix": "static_assertions-1.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.static_assertions-1.1.0.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__rustls-0.21.8": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3186,30 +2305,30 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustls-0.21.8.bazel"
             }
           },
-          "cui__gix-refspec-0.18.0": {
+          "cui__gix-config-value-0.14.8": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "0895cb7b1e70f3c3bd4550c329e9f5caf2975f97fcd4238e05754e72208ef61e",
+              "sha256": "03f76169faa0dec598eac60f83d7fcdd739ec16596eca8fb144c88973dbe6f8c",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-refspec/0.18.0/download"
+                "https://static.crates.io/crates/gix-config-value/0.14.8/download"
               ],
-              "strip_prefix": "gix-refspec-0.18.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-refspec-0.18.0.bazel"
+              "strip_prefix": "gix-config-value-0.14.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-config-value-0.14.8.bazel"
             }
           },
-          "cui__semver-1.0.20": {
+          "cui__prodash-28.0.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090",
+              "sha256": "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/semver/1.0.20/download"
+                "https://static.crates.io/crates/prodash/28.0.0/download"
               ],
-              "strip_prefix": "semver-1.0.20",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.semver-1.0.20.bazel"
+              "strip_prefix": "prodash-28.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.prodash-28.0.0.bazel"
             }
           },
           "rules_rust_proto__num_cpus-1.15.0": {
@@ -3238,17 +2357,30 @@
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
             }
           },
-          "rules_rust_bindgen__bitflags-2.4.1": {
+          "rules_rust_wasm_bindgen__termcolor-1.2.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07",
+              "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/bitflags/2.4.1/download"
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
               ],
-              "strip_prefix": "bitflags-2.4.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bitflags-2.4.1.bazel"
+              "strip_prefix": "termcolor-1.2.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
+            }
+          },
+          "cui__semver-1.0.23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/1.0.23/download"
+              ],
+              "strip_prefix": "semver-1.0.23",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.semver-1.0.23.bazel"
             }
           },
           "rrra__regex-syntax-0.7.4": {
@@ -3264,17 +2396,17 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
             }
           },
-          "rules_rust_prost__autocfg-1.1.0": {
+          "rules_rust_wasm_bindgen__hermit-abi-0.1.19": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "sha256": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/autocfg/1.1.0/download"
+                "https://static.crates.io/crates/hermit-abi/0.1.19/download"
               ],
-              "strip_prefix": "autocfg-1.1.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+              "strip_prefix": "hermit-abi-0.1.19",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.1.19.bazel"
             }
           },
           "rules_rust_wasm_bindgen__sct-0.7.1": {
@@ -3301,6 +2433,19 @@
               ],
               "strip_prefix": "winapi-util-0.1.5",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "cui__bstr-1.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bstr/1.6.0/download"
+              ],
+              "strip_prefix": "bstr-1.6.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bstr-1.6.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__strsim-0.10.0": {
@@ -3342,6 +2487,58 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.slab-0.4.7.bazel"
             }
           },
+          "rules_rust_proto__lock_api-0.3.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.3.4/download"
+              ],
+              "strip_prefix": "lock_api-0.3.4",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.lock_api-0.3.4.bazel"
+            }
+          },
+          "cui__filetime-0.2.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/filetime/0.2.22/download"
+              ],
+              "strip_prefix": "filetime-0.2.22",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.filetime-0.2.22.bazel"
+            }
+          },
+          "rules_rust_prost__fastrand-2.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/2.1.1/download"
+              ],
+              "strip_prefix": "fastrand-2.1.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.fastrand-2.1.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__log-0.4.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.22/download"
+              ],
+              "strip_prefix": "log-0.4.22",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.log-0.4.22.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__crossbeam-epoch-0.9.15": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3368,6 +2565,45 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
             }
           },
+          "rules_rust_bindgen__memchr-2.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.7.4/download"
+              ],
+              "strip_prefix": "memchr-2.7.4",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.memchr-2.7.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__unicode-width-0.1.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-width/0.1.13/download"
+              ],
+              "strip_prefix": "unicode-width-0.1.13",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.unicode-width-0.1.13.bazel"
+            }
+          },
+          "cui__indoc-2.0.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indoc/2.0.5/download"
+              ],
+              "strip_prefix": "indoc-2.0.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.indoc-2.0.5.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__errno-0.3.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3381,17 +2617,17 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.errno-0.3.1.bazel"
             }
           },
-          "rules_rust_bindgen__unicode-width-0.1.10": {
+          "rules_rust_prost__windows-targets-0.52.6": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/unicode-width/0.1.10/download"
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
               ],
-              "strip_prefix": "unicode-width-0.1.10",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.unicode-width-0.1.10.bazel"
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
             }
           },
           "rules_rust_proto__crossbeam-queue-0.2.3": {
@@ -3407,6 +2643,19 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-queue-0.2.3.bazel"
             }
           },
+          "cui__unicode-bom-2.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bom/2.0.2/download"
+              ],
+              "strip_prefix": "unicode-bom-2.0.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-bom-2.0.2.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__crossbeam-deque-0.8.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3420,6 +2669,71 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-deque-0.8.3.bazel"
             }
           },
+          "cui__gix-features-0.38.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-features/0.38.2/download"
+              ],
+              "strip_prefix": "gix-features-0.38.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-features-0.38.2.bazel"
+            }
+          },
+          "cui__smallvec-1.11.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/1.11.0/download"
+              ],
+              "strip_prefix": "smallvec-1.11.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smallvec-1.11.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__redox_syscall-0.3.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
+              ],
+              "strip_prefix": "redox_syscall-0.3.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
+            }
+          },
+          "cui__ignore-0.4.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ignore/0.4.18/download"
+              ],
+              "strip_prefix": "ignore-0.4.18",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ignore-0.4.18.bazel"
+            }
+          },
+          "cui__textwrap-0.16.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/textwrap/0.16.1/download"
+              ],
+              "strip_prefix": "textwrap-0.16.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.textwrap-0.16.1.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__wasi-0.11.0-wasi-snapshot-preview1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3431,6 +2745,58 @@
               ],
               "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-conventions-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8c04e3607b810e76768260db3a5f2e8beb477cb089ef8726da85c8eb9bd3b575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-wasm-conventions/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-wasm-conventions-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-conventions-0.2.92.bazel"
+            }
+          },
+          "cui__serde-1.0.210": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.210/download"
+              ],
+              "strip_prefix": "serde-1.0.210",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde-1.0.210.bazel"
+            }
+          },
+          "rules_rust_bindgen__proc-macro2-1.0.86": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.86/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.86",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.86.bazel"
             }
           },
           "rrra__colorchoice-1.0.0": {
@@ -3459,6 +2825,19 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-1.9.1.bazel"
             }
           },
+          "rules_rust_prost__slab-0.4.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.4.9/download"
+              ],
+              "strip_prefix": "slab-0.4.9",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.slab-0.4.9.bazel"
+            }
+          },
           "rrra__windows_x86_64_gnullvm-0.48.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3470,19 +2849,6 @@
               ],
               "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
-            }
-          },
-          "rules_rust_prost__slab-0.4.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/slab/0.4.8/download"
-              ],
-              "strip_prefix": "slab-0.4.8",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.slab-0.4.8.bazel"
             }
           },
           "rrra__clap-4.3.11": {
@@ -3498,6 +2864,84 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap-4.3.11.bazel"
             }
           },
+          "cui__valuable-0.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/valuable/0.1.0/download"
+              ],
+              "strip_prefix": "valuable-0.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.valuable-0.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__form_urlencoded-1.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/form_urlencoded/1.2.0/download"
+              ],
+              "strip_prefix": "form_urlencoded-1.2.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.form_urlencoded-1.2.0.bazel"
+            }
+          },
+          "cui__gix-protocol-0.45.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cc43a1006f01b5efee22a003928c9eb83dde2f52779ded9d4c0732ad93164e3e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-protocol/0.45.3/download"
+              ],
+              "strip_prefix": "gix-protocol-0.45.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-protocol-0.45.3.bazel"
+            }
+          },
+          "rules_rust_proto__cfg-if-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-core-0.1.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-core/0.1.18/download"
+              ],
+              "strip_prefix": "tokio-core-0.1.18",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-core-0.1.18.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
           "cui__adler-1.0.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3511,17 +2955,30 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.adler-1.0.2.bazel"
             }
           },
-          "rules_rust_prost__rustix-0.37.20": {
+          "cui__gix-index-0.35.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0",
+              "sha256": "0cd4203244444017682176e65fd0180be9298e58ed90bd4a8489a357795ed22d",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/rustix/0.37.20/download"
+                "https://static.crates.io/crates/gix-index/0.35.0/download"
               ],
-              "strip_prefix": "rustix-0.37.20",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustix-0.37.20.bazel"
+              "strip_prefix": "gix-index-0.35.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-index-0.35.0.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-utils-0.7.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.7.2/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.7.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-utils-0.7.2.bazel"
             }
           },
           "rules_rust_wasm_bindgen__wasm-bindgen-macro-support-0.2.92": {
@@ -3563,30 +3020,17 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
             }
           },
-          "cui__jwalk-0.8.1": {
+          "rules_rust_wasm_bindgen__float-cmp-0.8.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56",
+              "sha256": "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/jwalk/0.8.1/download"
+                "https://static.crates.io/crates/float-cmp/0.8.0/download"
               ],
-              "strip_prefix": "jwalk-0.8.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.jwalk-0.8.1.bazel"
-            }
-          },
-          "rules_rust_prost__getrandom-0.2.10": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/getrandom/0.2.10/download"
-              ],
-              "strip_prefix": "getrandom-0.2.10",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
+              "strip_prefix": "float-cmp-0.8.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.float-cmp-0.8.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__redox_syscall-0.2.16": {
@@ -3602,17 +3046,17 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.2.16.bazel"
             }
           },
-          "rules_rust_prost__httpdate-1.0.2": {
+          "rules_rust_prost__tower-layer-0.3.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421",
+              "sha256": "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/httpdate/1.0.2/download"
+                "https://static.crates.io/crates/tower-layer/0.3.3/download"
               ],
-              "strip_prefix": "httpdate-1.0.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.httpdate-1.0.2.bazel"
+              "strip_prefix": "tower-layer-0.3.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-layer-0.3.3.bazel"
             }
           },
           "cargo_bazel.buildifier-darwin-arm64": {
@@ -3620,76 +3064,115 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v7.1.1/buildifier-darwin-arm64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-arm64"
               ],
-              "integrity": "sha256-yZD0sDsn1qDYb/6TAUcypZwYurDE86TMVjS9OxYp/OM=",
+              "integrity": "sha256-Wmr8asegn1RVuguJvZnVriO0F03F3J1sDtXOjKrD+BM=",
               "downloaded_file_path": "buildifier",
               "executable": true
             }
           },
-          "cui__cargo_toml-0.19.2": {
+          "rules_rust_prost__getrandom-0.2.15": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be",
+              "sha256": "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/cargo_toml/0.19.2/download"
+                "https://static.crates.io/crates/getrandom/0.2.15/download"
               ],
-              "strip_prefix": "cargo_toml-0.19.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo_toml-0.19.2.bazel"
+              "strip_prefix": "getrandom-0.2.15",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.getrandom-0.2.15.bazel"
             }
           },
-          "rules_rust_prost__num_cpus-1.15.0": {
+          "rules_rust_prost__httpdate-1.0.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b",
+              "sha256": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/num_cpus/1.15.0/download"
+                "https://static.crates.io/crates/httpdate/1.0.3/download"
               ],
-              "strip_prefix": "num_cpus-1.15.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.num_cpus-1.15.0.bazel"
+              "strip_prefix": "httpdate-1.0.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.httpdate-1.0.3.bazel"
             }
           },
-          "rules_rust_bindgen__lazycell-1.3.0": {
+          "rules_rust_bindgen__is-terminal-0.4.13": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55",
+              "sha256": "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/lazycell/1.3.0/download"
+                "https://static.crates.io/crates/is-terminal/0.4.13/download"
               ],
-              "strip_prefix": "lazycell-1.3.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.lazycell-1.3.0.bazel"
+              "strip_prefix": "is-terminal-0.4.13",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.is-terminal-0.4.13.bazel"
             }
           },
-          "cui__tracing-subscriber-0.3.17": {
+          "cui__gix-traverse-0.41.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77",
+              "sha256": "030da39af94e4df35472e9318228f36530989327906f38e27807df305fccb780",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/tracing-subscriber/0.3.17/download"
+                "https://static.crates.io/crates/gix-traverse/0.41.0/download"
               ],
-              "strip_prefix": "tracing-subscriber-0.3.17",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-subscriber-0.3.17.bazel"
+              "strip_prefix": "gix-traverse-0.41.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-traverse-0.41.0.bazel"
             }
           },
-          "rules_rust_prost__bytes-1.4.0": {
+          "cui__serde_json-1.0.129": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be",
+              "sha256": "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/bytes/1.4.0/download"
+                "https://static.crates.io/crates/serde_json/1.0.129/download"
               ],
-              "strip_prefix": "bytes-1.4.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.bytes-1.4.0.bazel"
+              "strip_prefix": "serde_json-1.0.129",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_json-1.0.129.bazel"
+            }
+          },
+          "cui__winapi-i686-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "cui__tracing-subscriber-0.3.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-subscriber/0.3.18/download"
+              ],
+              "strip_prefix": "tracing-subscriber-0.3.18",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-subscriber-0.3.18.bazel"
             }
           },
           "rules_rust_wasm_bindgen__mime_guess-2.0.4": {
@@ -3705,6 +3188,19 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.mime_guess-2.0.4.bazel"
             }
           },
+          "rules_rust_wasm_bindgen__tinyvec_macros-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
+              ],
+              "strip_prefix": "tinyvec_macros-0.1.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
+            }
+          },
           "rules_rust_proto__protobuf-codegen-2.8.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3716,6 +3212,51 @@
               ],
               "strip_prefix": "protobuf-codegen-2.8.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.protobuf-codegen-2.8.2.bazel"
+            }
+          },
+          "rules_rust_prost__async-stream-0.3.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-stream/0.3.5/download"
+              ],
+              "strip_prefix": "async-stream-0.3.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.async-stream-0.3.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen_cli": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "08f61e21873f51e3059a8c7c3eef81ede7513d161cfc60751c7b2ffa6ed28270",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-cli/wasm-bindgen-cli-0.2.92.crate"
+              ],
+              "type": "tar.gz",
+              "strip_prefix": "wasm-bindgen-cli-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty:BUILD.wasm-bindgen-cli.bazel",
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust~//wasm_bindgen/3rdparty/patches:resolver.patch"
+              ]
+            }
+          },
+          "cui__regex-syntax-0.8.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.5/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-syntax-0.8.5.bazel"
             }
           },
           "rules_rust_wasm_bindgen__wasm-encoder-0.29.0": {
@@ -3731,56 +3272,69 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-encoder-0.29.0.bazel"
             }
           },
-          "cui__regex-syntax-0.8.2": {
+          "cui__tracing-log-0.2.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f",
+              "sha256": "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/regex-syntax/0.8.2/download"
+                "https://static.crates.io/crates/tracing-log/0.2.0/download"
               ],
-              "strip_prefix": "regex-syntax-0.8.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-syntax-0.8.2.bazel"
+              "strip_prefix": "tracing-log-0.2.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-log-0.2.0.bazel"
             }
           },
-          "rules_rust_bindgen__clap_lex-0.5.0": {
+          "cui__zerocopy-derive-0.7.35": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
+              "sha256": "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/clap_lex/0.5.0/download"
+                "https://static.crates.io/crates/zerocopy-derive/0.7.35/download"
               ],
-              "strip_prefix": "clap_lex-0.5.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
+              "strip_prefix": "zerocopy-derive-0.7.35",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.zerocopy-derive-0.7.35.bazel"
             }
           },
-          "rules_rust_prost__http-body-0.4.5": {
+          "cui__windows-sys-0.52.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1",
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/http-body/0.4.5/download"
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
               ],
-              "strip_prefix": "http-body-0.4.5",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-body-0.4.5.bazel"
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
             }
           },
-          "rules_rust_bindgen__utf8parse-0.2.1": {
+          "rules_rust_bindgen__utf8parse-0.2.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+              "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/utf8parse/0.2.1/download"
+                "https://static.crates.io/crates/utf8parse/0.2.2/download"
               ],
-              "strip_prefix": "utf8parse-0.2.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
+              "strip_prefix": "utf8parse-0.2.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.utf8parse-0.2.2.bazel"
+            }
+          },
+          "rules_rust_prost__multimap-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/multimap/0.10.0/download"
+              ],
+              "strip_prefix": "multimap-0.10.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.multimap-0.10.0.bazel"
             }
           },
           "rules_rust_proto__lazy_static-1.4.0": {
@@ -3796,6 +3350,32 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
             }
           },
+          "rules_rust_proto__tokio-threadpool-0.1.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-threadpool/0.1.18/download"
+              ],
+              "strip_prefix": "tokio-threadpool-0.1.18",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-threadpool-0.1.18.bazel"
+            }
+          },
+          "rules_rust_bindgen__either-1.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.13.0/download"
+              ],
+              "strip_prefix": "either-1.13.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.either-1.13.0.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__windows_x86_64_gnullvm-0.48.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3807,6 +3387,19 @@
               ],
               "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "cui__gix-0.66.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9048b8d1ae2104f045cb37e5c450fc49d5d8af22609386bfc739c11ba88995eb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix/0.66.0/download"
+              ],
+              "strip_prefix": "gix-0.66.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-0.66.0.bazel"
             }
           },
           "rules_rust_prost__fixedbitset-0.4.2": {
@@ -3822,6 +3415,45 @@
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.fixedbitset-0.4.2.bazel"
             }
           },
+          "rules_rust_bindgen__annotate-snippets-0.9.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/annotate-snippets/0.9.2/download"
+              ],
+              "strip_prefix": "annotate-snippets-0.9.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.annotate-snippets-0.9.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__httparse-1.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httparse/1.8.0/download"
+              ],
+              "strip_prefix": "httparse-1.8.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.httparse-1.8.0.bazel"
+            }
+          },
+          "rrra__strsim-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
           "rrra__winapi-i686-pc-windows-gnu-0.4.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3835,17 +3467,56 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
             }
           },
-          "rules_rust_prost__regex-1.8.4": {
+          "rules_rust_prost__futures-core-0.3.30": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f",
+              "sha256": "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/regex/1.8.4/download"
+                "https://static.crates.io/crates/futures-core/0.3.30/download"
               ],
-              "strip_prefix": "regex-1.8.4",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-1.8.4.bazel"
+              "strip_prefix": "futures-core-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-core-0.3.30.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__brotli-decompressor-2.5.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/brotli-decompressor/2.5.1/download"
+              ],
+              "strip_prefix": "brotli-decompressor-2.5.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.brotli-decompressor-2.5.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__unicode-normalization-0.1.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
+              ],
+              "strip_prefix": "unicode-normalization-0.1.22",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
             }
           },
           "cui__winapi-0.3.9": {
@@ -3861,17 +3532,30 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
             }
           },
-          "cui__syn-2.0.32": {
+          "rules_rust_prost__base64-0.22.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2",
+              "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/syn/2.0.32/download"
+                "https://static.crates.io/crates/base64/0.22.1/download"
               ],
-              "strip_prefix": "syn-2.0.32",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.syn-2.0.32.bazel"
+              "strip_prefix": "base64-0.22.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.base64-0.22.1.bazel"
+            }
+          },
+          "cui__gix-ignore-0.11.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e447cd96598460f5906a0f6c75e950a39f98c2705fc755ad2f2020c9e937fab7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-ignore/0.11.4/download"
+              ],
+              "strip_prefix": "gix-ignore-0.11.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-ignore-0.11.4.bazel"
             }
           },
           "rules_rust_wasm_bindgen__wasm-bindgen-externref-xform-0.2.92": {
@@ -3887,30 +3571,95 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-externref-xform-0.2.92.bazel"
             }
           },
-          "rules_rust_prost__rustversion-1.0.12": {
+          "rules_rust_wasm_bindgen__idna-0.4.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06",
+              "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/rustversion/1.0.12/download"
+                "https://static.crates.io/crates/idna/0.4.0/download"
               ],
-              "strip_prefix": "rustversion-1.0.12",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustversion-1.0.12.bazel"
+              "strip_prefix": "idna-0.4.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.idna-0.4.0.bazel"
             }
           },
-          "rules_rust_prost__tokio-macros-2.1.0": {
+          "rrra__regex-1.9.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e",
+              "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/tokio-macros/2.1.0/download"
+                "https://static.crates.io/crates/regex/1.9.1/download"
               ],
-              "strip_prefix": "tokio-macros-2.1.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-macros-2.1.0.bazel"
+              "strip_prefix": "regex-1.9.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-1.9.1.bazel"
+            }
+          },
+          "cui__anstyle-parse-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
+            }
+          },
+          "cui__gix-tempfile-14.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "046b4927969fa816a150a0cda2e62c80016fe11fb3c3184e4dddf4e542f108aa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-tempfile/14.0.2/download"
+              ],
+              "strip_prefix": "gix-tempfile-14.0.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-tempfile-14.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wait-timeout-0.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wait-timeout/0.2.0/download"
+              ],
+              "strip_prefix": "wait-timeout-0.2.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wait-timeout-0.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_aarch64_gnullvm-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__quick-error-1.2.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quick-error/1.2.3/download"
+              ],
+              "strip_prefix": "quick-error-1.2.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.quick-error-1.2.3.bazel"
             }
           },
           "rules_rust_wasm_bindgen__wasmprinter-0.2.60": {
@@ -3926,6 +3675,71 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmprinter-0.2.60.bazel"
             }
           },
+          "rules_rust_bindgen__winapi-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_prost__atomic-waker-1.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/atomic-waker/1.1.2/download"
+              ],
+              "strip_prefix": "atomic-waker-1.1.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.atomic-waker-1.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__rustversion-1.0.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustversion/1.0.17/download"
+              ],
+              "strip_prefix": "rustversion-1.0.17",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustversion-1.0.17.bazel"
+            }
+          },
+          "rules_rust_prost__lock_api-0.4.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.4.12/download"
+              ],
+              "strip_prefix": "lock_api-0.4.12",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.lock_api-0.4.12.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-threads-xform-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2d5add359b7f7d09a55299a9d29be54414264f2b8cf84f8c8fda5be9269b5dd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-threads-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-threads-xform-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-threads-xform-0.2.92.bazel"
+            }
+          },
           "rules_rust_proto__scoped-tls-0.1.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3937,19 +3751,6 @@
               ],
               "strip_prefix": "scoped-tls-0.1.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.scoped-tls-0.1.2.bazel"
-            }
-          },
-          "cui__gix-macros-0.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9d8acb5ee668d55f0f2d19a320a3f9ef67a6999ad483e11135abcc2464ed18b6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-macros/0.1.0/download"
-              ],
-              "strip_prefix": "gix-macros-0.1.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-macros-0.1.0.bazel"
             }
           },
           "rrra__ryu-1.0.14": {
@@ -3965,6 +3766,19 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
             }
           },
+          "rules_rust_prost__async-trait-0.1.81": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-trait/0.1.81/download"
+              ],
+              "strip_prefix": "async-trait-0.1.81",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.async-trait-0.1.81.bazel"
+            }
+          },
           "rrra__serde-1.0.171": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -3978,17 +3792,69 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde-1.0.171.bazel"
             }
           },
-          "rules_rust_prost__lock_api-0.4.10": {
+          "rules_rust_wasm_bindgen__core-foundation-sys-0.8.4": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16",
+              "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/lock_api/0.4.10/download"
+                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
               ],
-              "strip_prefix": "lock_api-0.4.10",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.lock_api-0.4.10.bazel"
+              "strip_prefix": "core-foundation-sys-0.8.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
+            }
+          },
+          "rrra__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rrra__anstyle-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-1.0.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
+            }
+          },
+          "cui__dunce-1.0.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/dunce/1.0.4/download"
+              ],
+              "strip_prefix": "dunce-1.0.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.dunce-1.0.4.bazel"
             }
           },
           "rules_rust_bindgen__glob-0.3.1": {
@@ -4004,17 +3870,43 @@
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.glob-0.3.1.bazel"
             }
           },
-          "rules_rust_prost__itertools-0.10.5": {
+          "cui__windows_aarch64_gnullvm-0.52.6": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473",
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/itertools/0.10.5/download"
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
               ],
-              "strip_prefix": "itertools-0.10.5",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.itertools-0.10.5.bazel"
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__memoffset-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memoffset/0.9.0/download"
+              ],
+              "strip_prefix": "memoffset-0.9.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__twoway-0.1.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/twoway/0.1.8/download"
+              ],
+              "strip_prefix": "twoway-0.1.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.twoway-0.1.8.bazel"
             }
           },
           "cui__redox_syscall-0.4.1": {
@@ -4030,6 +3922,19 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.4.1.bazel"
             }
           },
+          "rules_rust_bindgen__windows_aarch64_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__id-arena-2.2.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4043,108 +3948,160 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.id-arena-2.2.1.bazel"
             }
           },
-          "cui__normpath-1.1.1": {
+          "rules_rust_wasm_bindgen__linux-raw-sys-0.3.8": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5",
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/normpath/1.1.1/download"
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
               ],
-              "strip_prefix": "normpath-1.1.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.normpath-1.1.1.bazel"
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
             }
           },
-          "rules_rust_bindgen__lazy_static-1.4.0": {
+          "rules_rust_prost__bitflags-2.6.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+                "https://static.crates.io/crates/bitflags/2.6.0/download"
               ],
-              "strip_prefix": "lazy_static-1.4.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+              "strip_prefix": "bitflags-2.6.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.bitflags-2.6.0.bazel"
             }
           },
-          "rules_rust_prost__axum-0.6.18": {
+          "rules_rust_wasm_bindgen__safemem-0.3.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39",
+              "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/axum/0.6.18/download"
+                "https://static.crates.io/crates/safemem/0.3.3/download"
               ],
-              "strip_prefix": "axum-0.6.18",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.axum-0.6.18.bazel"
+              "strip_prefix": "safemem-0.3.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
             }
           },
-          "rules_rust_prost__parking_lot-0.12.1": {
+          "rules_rust_prost__unicode-ident-1.0.12": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
+              "sha256": "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/parking_lot/0.12.1/download"
+                "https://static.crates.io/crates/unicode-ident/1.0.12/download"
               ],
-              "strip_prefix": "parking_lot-0.12.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.parking_lot-0.12.1.bazel"
+              "strip_prefix": "unicode-ident-1.0.12",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.unicode-ident-1.0.12.bazel"
             }
           },
-          "cui__cargo-platform-0.1.4": {
+          "rules_rust_prost__indexmap-2.4.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36",
+              "sha256": "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/cargo-platform/0.1.4/download"
+                "https://static.crates.io/crates/indexmap/2.4.0/download"
               ],
-              "strip_prefix": "cargo-platform-0.1.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo-platform-0.1.4.bazel"
+              "strip_prefix": "indexmap-2.4.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.indexmap-2.4.0.bazel"
             }
           },
-          "cui__slug-0.1.4": {
+          "rules_rust_bindgen__shlex-1.3.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373",
+              "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/slug/0.1.4/download"
+                "https://static.crates.io/crates/shlex/1.3.0/download"
               ],
-              "strip_prefix": "slug-0.1.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.slug-0.1.4.bazel"
+              "strip_prefix": "shlex-1.3.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.shlex-1.3.0.bazel"
             }
           },
-          "rules_rust_prost__errno-dragonfly-0.1.2": {
+          "rules_rust_wasm_bindgen__assert_cmd-1.0.8": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "sha256": "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+                "https://static.crates.io/crates/assert_cmd/1.0.8/download"
               ],
-              "strip_prefix": "errno-dragonfly-0.1.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+              "strip_prefix": "assert_cmd-1.0.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.assert_cmd-1.0.8.bazel"
             }
           },
-          "cui__gix-url-0.24.0": {
+          "cui__gix-refspec-0.25.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "6125ecf46e8c68bf7202da6cad239831daebf0247ffbab30210d72f3856e420f",
+              "sha256": "ebb005f82341ba67615ffdd9f7742c87787544441c88090878393d0682869ca6",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-url/0.24.0/download"
+                "https://static.crates.io/crates/gix-refspec/0.25.0/download"
               ],
-              "strip_prefix": "gix-url-0.24.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-url-0.24.0.bazel"
+              "strip_prefix": "gix-refspec-0.25.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-refspec-0.25.0.bazel"
+            }
+          },
+          "rules_rust_prost__hashbrown-0.14.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.5/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hashbrown-0.14.5.bazel"
+            }
+          },
+          "rules_rust_prost__parking_lot-0.12.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.12.3/download"
+              ],
+              "strip_prefix": "parking_lot-0.12.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.parking_lot-0.12.3.bazel"
+            }
+          },
+          "cui__gix-revwalk-0.15.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b41e72544b93084ee682ef3d5b31b1ba4d8fa27a017482900e5e044d5b1b3984",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-revwalk/0.15.0/download"
+              ],
+              "strip_prefix": "gix-revwalk-0.15.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-revwalk-0.15.0.bazel"
+            }
+          },
+          "cui__serde_starlark-0.1.16": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "43f25f26c1c853647016b862c1734e0ad68c4f9f752b5f792220d38b1369ed4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_starlark/0.1.16/download"
+              ],
+              "strip_prefix": "serde_starlark-0.1.16",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_starlark-0.1.16.bazel"
             }
           },
           "rules_rust_wasm_bindgen__percent-encoding-2.3.0": {
@@ -4158,6 +4115,58 @@
               ],
               "strip_prefix": "percent-encoding-2.3.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.percent-encoding-2.3.0.bazel"
+            }
+          },
+          "rules_rust_prost__wasi-0.11.0-wasi-snapshot-preview1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+              ],
+              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "cui__cargo-platform-0.1.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo-platform/0.1.7/download"
+              ],
+              "strip_prefix": "cargo-platform-0.1.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo-platform-0.1.7.bazel"
+            }
+          },
+          "cui__gix-odb-0.63.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a3158068701c17df54f0ab2adda527f5a6aca38fd5fd80ceb7e3c0a2717ec747",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-odb/0.63.0/download"
+              ],
+              "strip_prefix": "gix-odb-0.63.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-odb-0.63.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustix-0.37.23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
             }
           },
           "cui__clap_builder-4.3.11": {
@@ -4186,6 +4195,45 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-core-0.1.32.bazel"
             }
           },
+          "rrra__clap_lex-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
+              ],
+              "strip_prefix": "clap_lex-0.5.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
+            }
+          },
+          "rules_rust_proto__log-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.3.9/download"
+              ],
+              "strip_prefix": "log-0.3.9",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.log-0.3.9.bazel"
+            }
+          },
+          "rules_rust_prost__rustix-0.38.34": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.38.34/download"
+              ],
+              "strip_prefix": "rustix-0.38.34",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustix-0.38.34.bazel"
+            }
+          },
           "rules_rust_proto__fuchsia-zircon-sys-0.3.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4212,6 +4260,45 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
             }
           },
+          "cui__quote-1.0.37": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_i686_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__home-0.5.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/home/0.5.5/download"
+              ],
+              "strip_prefix": "home-0.5.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.home-0.5.5.bazel"
+            }
+          },
           "cui__windows_x86_64_gnu-0.48.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4225,17 +4312,30 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
             }
           },
-          "cui__gix-actor-0.27.0": {
+          "rules_rust_proto__memoffset-0.5.6": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "08c60e982c5290897122d4e2622447f014a2dadd5a18cb73d50bb91b31645e27",
+              "sha256": "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-actor/0.27.0/download"
+                "https://static.crates.io/crates/memoffset/0.5.6/download"
               ],
-              "strip_prefix": "gix-actor-0.27.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-actor-0.27.0.bazel"
+              "strip_prefix": "memoffset-0.5.6",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.memoffset-0.5.6.bazel"
+            }
+          },
+          "rules_rust_prost__prettyplease-0.2.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prettyplease/0.2.22/download"
+              ],
+              "strip_prefix": "prettyplease-0.2.22",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prettyplease-0.2.22.bazel"
             }
           },
           "cui__unic-ucd-version-0.9.0": {
@@ -4327,6 +4427,19 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-interpreter-0.2.92.bazel"
             }
           },
+          "rules_rust_wasm_bindgen__predicates-2.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates/2.1.5/download"
+              ],
+              "strip_prefix": "predicates-2.1.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-2.1.5.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__ring-0.17.5": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4340,30 +4453,30 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ring-0.17.5.bazel"
             }
           },
-          "rules_rust_prost__memchr-2.5.0": {
+          "rules_rust_prost__either-1.13.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+              "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/memchr/2.5.0/download"
+                "https://static.crates.io/crates/either/1.13.0/download"
               ],
-              "strip_prefix": "memchr-2.5.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
+              "strip_prefix": "either-1.13.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.either-1.13.0.bazel"
             }
           },
-          "cui__crates-index-2.2.0": {
+          "cui__jiff-tzdb-0.1.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "33bc10579ea08741ae173928194b6c42c90b295d51ddd0d18238eaf15502ac87",
+              "sha256": "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/crates-index/2.2.0/download"
+                "https://static.crates.io/crates/jiff-tzdb/0.1.1/download"
               ],
-              "strip_prefix": "crates-index-2.2.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crates-index-2.2.0.bazel"
+              "strip_prefix": "jiff-tzdb-0.1.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.jiff-tzdb-0.1.1.bazel"
             }
           },
           "rules_rust_proto__winapi-0.3.9": {
@@ -4377,6 +4490,19 @@
               ],
               "strip_prefix": "winapi-0.3.9",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "cui__windows_x86_64_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__crossbeam-channel-0.5.8": {
@@ -4405,6 +4531,19 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
             }
           },
+          "cui__redox_syscall-0.3.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
+              ],
+              "strip_prefix": "redox_syscall-0.3.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__flate2-1.0.28": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4416,6 +4555,19 @@
               ],
               "strip_prefix": "flate2-1.0.28",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__indexmap-1.9.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/1.9.3/download"
+              ],
+              "strip_prefix": "indexmap-1.9.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
             }
           },
           "rules_rust_proto__semver-0.9.0": {
@@ -4431,6 +4583,71 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.semver-0.9.0.bazel"
             }
           },
+          "rules_rust_wasm_bindgen__once_cell-1.18.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
+              ],
+              "strip_prefix": "once_cell-1.18.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
+            }
+          },
+          "cui__cargo-lock-10.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "49f8d8bb8836f681fe20ad10faa7796a11e67dbb6125e5a38f88ddd725c217e8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo-lock/10.0.0/download"
+              ],
+              "strip_prefix": "cargo-lock-10.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo-lock-10.0.0.bazel"
+            }
+          },
+          "rules_rust_prost__gimli-0.29.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gimli/0.29.0/download"
+              ],
+              "strip_prefix": "gimli-0.29.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.gimli-0.29.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__termtree-0.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termtree/0.4.1/download"
+              ],
+              "strip_prefix": "termtree-0.4.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.termtree-0.4.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__clang-sys-1.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clang-sys/1.8.1/download"
+              ],
+              "strip_prefix": "clang-sys-1.8.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clang-sys-1.8.1.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__scopeguard-1.1.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4442,6 +4659,45 @@
               ],
               "strip_prefix": "scopeguard-1.1.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
+            }
+          },
+          "cui__ahash-0.8.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ahash/0.8.11/download"
+              ],
+              "strip_prefix": "ahash-0.8.11",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ahash-0.8.11.bazel"
+            }
+          },
+          "cui__linux-raw-sys-0.4.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.4.14/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.4.14",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.4.14.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__doc-comment-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/doc-comment/0.3.3/download"
+              ],
+              "strip_prefix": "doc-comment-0.3.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.doc-comment-0.3.3.bazel"
             }
           },
           "rules_rust_wasm_bindgen__fastrand-1.9.0": {
@@ -4470,17 +4726,30 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num_threads-0.1.6.bazel"
             }
           },
-          "cui__rayon-core-1.12.0": {
+          "rules_rust_bindgen__windows_x86_64_msvc-0.52.6": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed",
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/rayon-core/1.12.0/download"
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
               ],
-              "strip_prefix": "rayon-core-1.12.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rayon-core-1.12.0.bazel"
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "cui__crc32fast-1.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
+              ],
+              "strip_prefix": "crc32fast-1.3.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
             }
           },
           "rules_rust_wasm_bindgen__lazy_static-1.4.0": {
@@ -4496,6 +4765,19 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
             }
           },
+          "cui__gix-revision-0.29.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ba4621b219ac0cdb9256883030c3d56a6c64a6deaa829a92da73b9a576825e1e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-revision/0.29.0/download"
+              ],
+              "strip_prefix": "gix-revision-0.29.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-revision-0.29.0.bazel"
+            }
+          },
           "cui__thread_local-1.1.4": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4507,6 +4789,32 @@
               ],
               "strip_prefix": "thread_local-1.1.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thread_local-1.1.4.bazel"
+            }
+          },
+          "cui__gix-worktree-0.36.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c312ad76a3f2ba8e865b360d5cb3aa04660971d16dec6dd0ce717938d903149a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-worktree/0.36.0/download"
+              ],
+              "strip_prefix": "gix-worktree-0.36.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-worktree-0.36.0.bazel"
+            }
+          },
+          "cui__jiff-0.1.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/jiff/0.1.13/download"
+              ],
+              "strip_prefix": "jiff-0.1.13",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.jiff-0.1.13.bazel"
             }
           },
           "rules_rust_wasm_bindgen__threadpool-1.8.1": {
@@ -4522,30 +4830,17 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.threadpool-1.8.1.bazel"
             }
           },
-          "cui__linux-raw-sys-0.4.10": {
+          "rules_rust_wasm_bindgen__walrus-macro-0.19.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f",
+              "sha256": "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/linux-raw-sys/0.4.10/download"
+                "https://static.crates.io/crates/walrus-macro/0.19.0/download"
               ],
-              "strip_prefix": "linux-raw-sys-0.4.10",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.4.10.bazel"
-            }
-          },
-          "rules_rust_bindgen__anstyle-wincon-1.0.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
-              ],
-              "strip_prefix": "anstyle-wincon-1.0.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
+              "strip_prefix": "walrus-macro-0.19.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.walrus-macro-0.19.0.bazel"
             }
           },
           "rrra__windows_x86_64_msvc-0.48.0": {
@@ -4561,43 +4856,56 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
             }
           },
-          "cui__rand_core-0.3.1": {
+          "cui__shell-words-1.1.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b",
+              "sha256": "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/rand_core/0.3.1/download"
+                "https://static.crates.io/crates/shell-words/1.1.0/download"
               ],
-              "strip_prefix": "rand_core-0.3.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_core-0.3.1.bazel"
+              "strip_prefix": "shell-words-1.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.shell-words-1.1.0.bazel"
             }
           },
-          "cui__rayon-1.8.0": {
+          "cui__syn-2.0.79": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1",
+              "sha256": "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/rayon/1.8.0/download"
+                "https://static.crates.io/crates/syn/2.0.79/download"
               ],
-              "strip_prefix": "rayon-1.8.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rayon-1.8.0.bazel"
+              "strip_prefix": "syn-2.0.79",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.syn-2.0.79.bazel"
             }
           },
-          "cui__tempfile-3.8.1": {
+          "rules_rust_bindgen__unicode-ident-1.0.13": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5",
+              "sha256": "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/tempfile/3.8.1/download"
+                "https://static.crates.io/crates/unicode-ident/1.0.13/download"
               ],
-              "strip_prefix": "tempfile-3.8.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tempfile-3.8.1.bazel"
+              "strip_prefix": "unicode-ident-1.0.13",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.13.bazel"
+            }
+          },
+          "cui__cpufeatures-0.2.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cpufeatures/0.2.9/download"
+              ],
+              "strip_prefix": "cpufeatures-0.2.9",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cpufeatures-0.2.9.bazel"
             }
           },
           "rules_rust_wasm_bindgen__windows_aarch64_msvc-0.48.0": {
@@ -4613,6 +4921,45 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
             }
           },
+          "rules_rust_proto__base64-0.9.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.9.3/download"
+              ],
+              "strip_prefix": "base64-0.9.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.base64-0.9.3.bazel"
+            }
+          },
+          "rules_rust_prost__rustc-demangle-0.1.24": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-demangle/0.1.24/download"
+              ],
+              "strip_prefix": "rustc-demangle-0.1.24",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustc-demangle-0.1.24.bazel"
+            }
+          },
+          "rrra__anyhow-1.0.71": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
+              ],
+              "strip_prefix": "anyhow-1.0.71",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__multipart-0.18.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4624,6 +4971,45 @@
               ],
               "strip_prefix": "multipart-0.18.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.multipart-0.18.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows-sys-0.59.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
+            }
+          },
+          "cui__windows_i686_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__proc-macro2-1.0.86": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.86/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.86",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.proc-macro2-1.0.86.bazel"
             }
           },
           "rules_rust_wasm_bindgen__android_system_properties-0.1.5": {
@@ -4639,56 +5025,17 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.android_system_properties-0.1.5.bazel"
             }
           },
-          "cui__gix-ref-0.37.0": {
+          "rules_rust_wasm_bindgen__cc-1.0.83": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "22e6b749660b613641769edc1954132eb8071a13c32224891686091bef078de4",
+              "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-ref/0.37.0/download"
+                "https://static.crates.io/crates/cc/1.0.83/download"
               ],
-              "strip_prefix": "gix-ref-0.37.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-ref-0.37.0.bazel"
-            }
-          },
-          "cui__rand-0.8.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand/0.8.5/download"
-              ],
-              "strip_prefix": "rand-0.8.5",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand-0.8.5.bazel"
-            }
-          },
-          "cui__num-integer-0.1.45": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/num-integer/0.1.45/download"
-              ],
-              "strip_prefix": "num-integer-0.1.45",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-integer-0.1.45.bazel"
-            }
-          },
-          "rules_rust_bindgen__anstyle-query-1.0.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
-              ],
-              "strip_prefix": "anstyle-query-1.0.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
+              "strip_prefix": "cc-1.0.83",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.cc-1.0.83.bazel"
             }
           },
           "rules_rust_wasm_bindgen__hermit-abi-0.3.2": {
@@ -4704,6 +5051,32 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
             }
           },
+          "rrra__utf8parse-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
+            }
+          },
+          "cui__gix-date-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "35c84b7af01e68daf7a6bb8bb909c1ff5edb3ce4326f1f43063a5a96d3c3c8a5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-date/0.9.0/download"
+              ],
+              "strip_prefix": "gix-date-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-date-0.9.0.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__getrandom-0.2.10": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4715,6 +5088,31 @@
               ],
               "strip_prefix": "getrandom-0.2.10",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
+            }
+          },
+          "rules_rust_proto__futures-cpupool-0.1.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-cpupool/0.1.8/download"
+              ],
+              "strip_prefix": "futures-cpupool-0.1.8",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.futures-cpupool-0.1.8.bazel"
+            }
+          },
+          "cargo_bazel.buildifier-windows-amd64.exe": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-windows-amd64.exe"
+              ],
+              "integrity": "sha256-NwzVdgda0pkwqC9d4TLxod5AhMeEqCUUvU2oDIWs9Kg=",
+              "downloaded_file_path": "buildifier.exe",
+              "executable": true
             }
           },
           "rules_rust_proto__smallvec-0.6.14": {
@@ -4730,30 +5128,56 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.smallvec-0.6.14.bazel"
             }
           },
-          "rules_rust_prost__httparse-1.8.0": {
+          "cui__normpath-1.3.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
+              "sha256": "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/httparse/1.8.0/download"
+                "https://static.crates.io/crates/normpath/1.3.0/download"
               ],
-              "strip_prefix": "httparse-1.8.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.httparse-1.8.0.bazel"
+              "strip_prefix": "normpath-1.3.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.normpath-1.3.0.bazel"
             }
           },
-          "rules_rust_bindgen__shlex-1.1.0": {
+          "rrra__log-0.4.19": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3",
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/shlex/1.1.0/download"
+                "https://static.crates.io/crates/log/0.4.19/download"
               ],
-              "strip_prefix": "shlex-1.1.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.shlex-1.1.0.bazel"
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "cui__cargo_metadata-0.18.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo_metadata/0.18.1/download"
+              ],
+              "strip_prefix": "cargo_metadata-0.18.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo_metadata-0.18.1.bazel"
             }
           },
           "rules_rust_wasm_bindgen__predicates-1.0.8": {
@@ -4795,6 +5219,19 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
             }
           },
+          "rules_rust_bindgen__quote-1.0.37": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__serde_json-1.0.102": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4806,6 +5243,19 @@
               ],
               "strip_prefix": "serde_json-1.0.102",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
+            }
+          },
+          "cui__gix-ref-0.47.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ae0d8406ebf9aaa91f55a57f053c5a1ad1a39f60fdf0303142b7be7ea44311e5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-ref/0.47.0/download"
+              ],
+              "strip_prefix": "gix-ref-0.47.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-ref-0.47.0.bazel"
             }
           },
           "rrra__clap_builder-4.3.11": {
@@ -4821,19 +5271,6 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_builder-4.3.11.bazel"
             }
           },
-          "rules_rust_prost__windows-sys-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows-sys/0.48.0/download"
-              ],
-              "strip_prefix": "windows-sys-0.48.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
-            }
-          },
           "rules_rust_wasm_bindgen__windows_i686_gnu-0.48.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -4845,19 +5282,6 @@
               ],
               "strip_prefix": "windows_i686_gnu-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
-            }
-          },
-          "cui__gix-lock-10.0.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "47fc96fa8b6b6d33555021907c81eb3b27635daecf6e630630bdad44f8feaa95",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-lock/10.0.0/download"
-              ],
-              "strip_prefix": "gix-lock-10.0.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-lock-10.0.0.bazel"
             }
           },
           "rules_rust_prost__indexmap-1.9.3": {
@@ -4873,17 +5297,17 @@
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
             }
           },
-          "cui__num-iter-0.1.43": {
+          "cui__gix-glob-0.16.5": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252",
+              "sha256": "74908b4bbc0a0a40852737e5d7889f676f081e340d5451a16e5b4c50d592f111",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/num-iter/0.1.43/download"
+                "https://static.crates.io/crates/gix-glob/0.16.5/download"
               ],
-              "strip_prefix": "num-iter-0.1.43",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-iter-0.1.43.bazel"
+              "strip_prefix": "gix-glob-0.16.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-glob-0.16.5.bazel"
             }
           },
           "rules_rust_wasm_bindgen__ryu-1.0.14": {
@@ -4899,30 +5323,82 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
             }
           },
-          "rules_rust_prost__lazy_static-1.4.0": {
+          "rules_rust_wasm_bindgen__io-lifetimes-1.0.11": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
               ],
-              "strip_prefix": "lazy_static-1.4.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
             }
           },
-          "rules_rust_prost__multimap-0.8.3": {
+          "rules_rust_bindgen__windows_aarch64_gnullvm-0.52.6": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a",
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/multimap/0.8.3/download"
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
               ],
-              "strip_prefix": "multimap-0.8.3",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.multimap-0.8.3.bazel"
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__diff-0.1.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/diff/0.1.13/download"
+              ],
+              "strip_prefix": "diff-0.1.13",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.diff-0.1.13.bazel"
+            }
+          },
+          "rules_rust_prost__tower-service-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower-service/0.3.3/download"
+              ],
+              "strip_prefix": "tower-service-0.3.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-service-0.3.3.bazel"
+            }
+          },
+          "rules_rust_bindgen__aho-corasick-1.1.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.3/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.3",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.aho-corasick-1.1.3.bazel"
+            }
+          },
+          "cui__tempfile-3.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.13.0/download"
+              ],
+              "strip_prefix": "tempfile-3.13.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tempfile-3.13.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__difference-2.0.0": {
@@ -4990,6 +5466,32 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustls-webpki-0.101.7.bazel"
             }
           },
+          "rules_rust_wasm_bindgen__winapi-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "cui__gix-sec-0.10.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0fe4d52f30a737bbece5276fab5d3a8b276dc2650df963e293d0673be34e7a5f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-sec/0.10.8/download"
+              ],
+              "strip_prefix": "gix-sec-0.10.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-sec-0.10.8.bazel"
+            }
+          },
           "rules_rust_prost": {
             "bzlFile": "@@rules_rust~//crate_universe/private:crates_vendor.bzl",
             "ruleClassName": "crates_vendor_remote_repository",
@@ -4998,17 +5500,69 @@
               "defs_module": "@@rules_rust~//proto/prost/private/3rdparty/crates:defs.bzl"
             }
           },
-          "rules_rust_bindgen__quote-1.0.28": {
+          "rules_rust_prost__pin-project-1.1.5": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488",
+              "sha256": "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/quote/1.0.28/download"
+                "https://static.crates.io/crates/pin-project/1.1.5/download"
               ],
-              "strip_prefix": "quote-1.0.28",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.quote-1.0.28.bazel"
+              "strip_prefix": "pin-project-1.1.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-1.1.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__hermit-abi-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.4.0/download"
+              ],
+              "strip_prefix": "hermit-abi-0.4.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.hermit-abi-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__itertools-0.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.13.0/download"
+              ],
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-parse-0.2.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.5/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.5",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-parse-0.2.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.102.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.102.0/download"
+              ],
+              "strip_prefix": "wasmparser-0.102.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.102.0.bazel"
             }
           },
           "cui__anstyle-query-1.0.0": {
@@ -5024,17 +5578,69 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
             }
           },
-          "cui__bumpalo-3.13.0": {
+          "cui__winapi-x86_64-pc-windows-gnu-0.4.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/bumpalo/3.13.0/download"
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
               ],
-              "strip_prefix": "bumpalo-3.13.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_derive-4.5.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.5.13/download"
+              ],
+              "strip_prefix": "clap_derive-4.5.13",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_derive-4.5.13.bazel"
+            }
+          },
+          "rules_rust_proto__grpc-compiler-0.6.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "907274ce8ee7b40a0d0b0db09022ea22846a47cfb1fc8ad2c983c70001b4ffb1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/grpc-compiler/0.6.2/download"
+              ],
+              "strip_prefix": "grpc-compiler-0.6.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.grpc-compiler-0.6.2.bazel"
+            }
+          },
+          "rrra__heck-0.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.4.1/download"
+              ],
+              "strip_prefix": "heck-0.4.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.heck-0.4.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__autocfg-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
             }
           },
           "rules_rust_prost__cfg-if-1.0.0": {
@@ -5050,69 +5656,56 @@
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
             }
           },
-          "rules_rust_bindgen__anstyle-parse-0.2.0": {
+          "cui__version_check-0.9.4": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee",
+              "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/anstyle-parse/0.2.0/download"
+                "https://static.crates.io/crates/version_check/0.9.4/download"
               ],
-              "strip_prefix": "anstyle-parse-0.2.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-parse-0.2.0.bazel"
+              "strip_prefix": "version_check-0.9.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
             }
           },
-          "rules_rust_bindgen__bindgen-0.69.1": {
+          "rules_rust_bindgen__regex-1.10.6": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2",
+              "sha256": "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/bindgen/0.69.1/download"
+                "https://static.crates.io/crates/regex/1.10.6/download"
               ],
-              "strip_prefix": "bindgen-0.69.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bindgen-0.69.1.bazel"
+              "strip_prefix": "regex-1.10.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-1.10.6.bazel"
             }
           },
-          "cui__num-complex-0.1.43": {
+          "cui__regex-1.11.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656",
+              "sha256": "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/num-complex/0.1.43/download"
+                "https://static.crates.io/crates/regex/1.11.0/download"
               ],
-              "strip_prefix": "num-complex-0.1.43",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-complex-0.1.43.bazel"
+              "strip_prefix": "regex-1.11.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-1.11.0.bazel"
             }
           },
-          "cui__once_cell-1.19.0": {
+          "cui__scopeguard-1.2.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+              "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/once_cell/1.19.0/download"
+                "https://static.crates.io/crates/scopeguard/1.2.0/download"
               ],
-              "strip_prefix": "once_cell-1.19.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.once_cell-1.19.0.bazel"
-            }
-          },
-          "rules_rust_prost__pin-project-1.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/pin-project/1.1.0/download"
-              ],
-              "strip_prefix": "pin-project-1.1.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-1.1.0.bazel"
+              "strip_prefix": "scopeguard-1.2.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__quote-1.0.29": {
@@ -5128,17 +5721,17 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.quote-1.0.29.bazel"
             }
           },
-          "cui__parse-zoneinfo-0.3.0": {
+          "rules_rust_bindgen__bindgen-cli-0.70.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41",
+              "integrity": "sha256-Mz+eRtWNh1r7irkjwi27fmF4j1WtKPK12Yv5ENkL1ao=",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/parse-zoneinfo/0.3.0/download"
+                "https://static.crates.io/crates/bindgen-cli/bindgen-cli-0.70.1.crate"
               ],
-              "strip_prefix": "parse-zoneinfo-0.3.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.parse-zoneinfo-0.3.0.bazel"
+              "strip_prefix": "bindgen-cli-0.70.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty:BUILD.bindgen-cli.bazel"
             }
           },
           "cui__unicode-bidi-0.3.13": {
@@ -5154,17 +5747,17 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
             }
           },
-          "cui__gix-traverse-0.33.0": {
+          "rrra__anstyle-parse-0.2.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "22ef04ab3643acba289b5cedd25d6f53c0430770b1d689d1d654511e6fb81ba0",
+              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-traverse/0.33.0/download"
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
               ],
-              "strip_prefix": "gix-traverse-0.33.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-traverse-0.33.0.bazel"
+              "strip_prefix": "anstyle-parse-0.2.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
             }
           },
           "rules_rust_wasm_bindgen__stable_deref_trait-1.2.0": {
@@ -5193,6 +5786,64 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.ws2_32-sys-0.2.1.bazel"
             }
           },
+          "rules_rust_wasm_bindgen__num_cpus-1.16.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_cpus/1.16.0/download"
+              ],
+              "strip_prefix": "num_cpus-1.16.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num_cpus-1.16.0.bazel"
+            }
+          },
+          "cui__gix-fs-0.11.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f2bfe6249cfea6d0c0e0990d5226a4cb36f030444ba9e35e0639275db8f98575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-fs/0.11.3/download"
+              ],
+              "strip_prefix": "gix-fs-0.11.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-fs-0.11.3.bazel"
+            }
+          },
+          "rules_rust_prost__adler-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "llvm-raw": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-project-14.0.6.src.tar.xz"
+              ],
+              "strip_prefix": "llvm-project-14.0.6.src",
+              "sha256": "8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a",
+              "build_file_content": "# empty",
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust~//bindgen/3rdparty/patches:llvm-project.cxx17.patch",
+                "@@rules_rust~//bindgen/3rdparty/patches:llvm-project.incompatible_disallow_empty_glob.patch"
+              ]
+            }
+          },
           "cui__miniz_oxide-0.7.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -5206,17 +5857,43 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
             }
           },
-          "rules_rust_bindgen__io-lifetimes-1.0.11": {
+          "cui__faster-hex-0.9.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "sha256": "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+                "https://static.crates.io/crates/faster-hex/0.9.0/download"
               ],
-              "strip_prefix": "io-lifetimes-1.0.11",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+              "strip_prefix": "faster-hex-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.faster-hex-0.9.0.bazel"
+            }
+          },
+          "cui__winapi-util-0.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-current-thread-0.1.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-current-thread/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-current-thread-0.1.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-current-thread-0.1.7.bazel"
             }
           },
           "cui__unic-char-range-0.9.0": {
@@ -5297,4992 +5974,6 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-0.2.92.bazel"
             }
           },
-          "rules_rust_prost__winapi-i686-pc-windows-gnu-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
-              ],
-              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
-            }
-          },
-          "cui__regex-automata-0.3.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/regex-automata/0.3.3/download"
-              ],
-              "strip_prefix": "regex-automata-0.3.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
-            }
-          },
-          "rrra__windows_aarch64_msvc-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
-              ],
-              "strip_prefix": "windows_aarch64_msvc-0.48.0",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
-            }
-          },
-          "rules_rust_prost__which-4.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/which/4.4.0/download"
-              ],
-              "strip_prefix": "which-4.4.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.which-4.4.0.bazel"
-            }
-          },
-          "rrra__anstyle-wincon-1.0.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
-              ],
-              "strip_prefix": "anstyle-wincon-1.0.1",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__adler-1.0.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/adler/1.0.2/download"
-              ],
-              "strip_prefix": "adler-1.0.2",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.adler-1.0.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__log-0.4.19": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/log/0.4.19/download"
-              ],
-              "strip_prefix": "log-0.4.19",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.log-0.4.19.bazel"
-            }
-          },
-          "rules_rust_bindgen__heck-0.4.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/heck/0.4.1/download"
-              ],
-              "strip_prefix": "heck-0.4.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.heck-0.4.1.bazel"
-            }
-          },
-          "cui__digest-0.10.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/digest/0.10.7/download"
-              ],
-              "strip_prefix": "digest-0.10.7",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.digest-0.10.7.bazel"
-            }
-          },
-          "cui__equivalent-1.0.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/equivalent/1.0.1/download"
-              ],
-              "strip_prefix": "equivalent-1.0.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
-            }
-          },
-          "cui": {
-            "bzlFile": "@@rules_rust~//crate_universe/private:crates_vendor.bzl",
-            "ruleClassName": "crates_vendor_remote_repository",
-            "attributes": {
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bazel",
-              "defs_module": "@@rules_rust~//crate_universe/3rdparty/crates:defs.bzl"
-            }
-          },
-          "rules_rust_wasm_bindgen__memchr-2.5.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/memchr/2.5.0/download"
-              ],
-              "strip_prefix": "memchr-2.5.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
-            }
-          },
-          "rrra__once_cell-1.18.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/once_cell/1.18.0/download"
-              ],
-              "strip_prefix": "once_cell-1.18.0",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
-            }
-          },
-          "rules_rust_proto__tokio-tls-api-0.1.22": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "68d0e040d5b1f4cfca70ec4f371229886a5de5bb554d272a4a8da73004a7b2c9",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-tls-api/0.1.22/download"
-              ],
-              "strip_prefix": "tokio-tls-api-0.1.22",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-tls-api-0.1.22.bazel"
-            }
-          },
-          "rules_rust_bindgen__is-terminal-0.4.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/is-terminal/0.4.7/download"
-              ],
-              "strip_prefix": "is-terminal-0.4.7",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
-            }
-          },
-          "cui__autocfg-1.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/autocfg/1.1.0/download"
-              ],
-              "strip_prefix": "autocfg-1.1.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
-            }
-          },
-          "rules_rust_prost__tokio-util-0.7.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-util/0.7.8/download"
-              ],
-              "strip_prefix": "tokio-util-0.7.8",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-util-0.7.8.bazel"
-            }
-          },
-          "rules_rust_prost__tokio-io-timeout-1.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-io-timeout/1.2.0/download"
-              ],
-              "strip_prefix": "tokio-io-timeout-1.2.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-io-timeout-1.2.0.bazel"
-            }
-          },
-          "cui__num-traits-0.2.15": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/num-traits/0.2.15/download"
-              ],
-              "strip_prefix": "num-traits-0.2.15",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-traits-0.2.15.bazel"
-            }
-          },
-          "rules_rust_proto__winapi-build-0.1.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-build/0.1.1/download"
-              ],
-              "strip_prefix": "winapi-build-0.1.1",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-build-0.1.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__base64-0.13.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/base64/0.13.1/download"
-              ],
-              "strip_prefix": "base64-0.13.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.base64-0.13.1.bazel"
-            }
-          },
-          "rules_rust_proto__parking_lot-0.9.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/parking_lot/0.9.0/download"
-              ],
-              "strip_prefix": "parking_lot-0.9.0",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.parking_lot-0.9.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__humantime-2.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/humantime/2.1.0/download"
-              ],
-              "strip_prefix": "humantime-2.1.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__rand_chacha-0.3.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
-              ],
-              "strip_prefix": "rand_chacha-0.3.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
-            }
-          },
-          "cui__strsim-0.10.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/strsim/0.10.0/download"
-              ],
-              "strip_prefix": "strsim-0.10.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
-            }
-          },
-          "rules_rust_prost__windows_aarch64_gnullvm-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
-              ],
-              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
-            }
-          },
-          "cui__cfg-if-1.0.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/cfg-if/1.0.0/download"
-              ],
-              "strip_prefix": "cfg-if-1.0.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
-            }
-          },
-          "cui__errno-dragonfly-0.1.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
-              ],
-              "strip_prefix": "errno-dragonfly-0.1.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
-            }
-          },
-          "rules_rust_bindgen__regex-syntax-0.7.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/regex-syntax/0.7.2/download"
-              ],
-              "strip_prefix": "regex-syntax-0.7.2",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-syntax-0.7.2.bazel"
-            }
-          },
-          "cui__proc-macro2-1.0.64": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
-              ],
-              "strip_prefix": "proc-macro2-1.0.64",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
-            }
-          },
-          "cui__gix-prompt-0.7.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5c9a913769516f5e9d937afac206fb76428e3d7238e538845842887fda584678",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-prompt/0.7.0/download"
-              ],
-              "strip_prefix": "gix-prompt-0.7.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-prompt-0.7.0.bazel"
-            }
-          },
-          "cui__thiserror-impl-1.0.50": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/thiserror-impl/1.0.50/download"
-              ],
-              "strip_prefix": "thiserror-impl-1.0.50",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thiserror-impl-1.0.50.bazel"
-            }
-          },
-          "rules_rust_prost__either-1.8.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/either/1.8.1/download"
-              ],
-              "strip_prefix": "either-1.8.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.either-1.8.1.bazel"
-            }
-          },
-          "rules_rust_bindgen__bindgen-cli-0.69.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "integrity": "sha256-iFZe4JEQqZ54KZiX+/7VA7mqAwZThu6MGBl/yvIotQE=",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bindgen-cli/bindgen-cli-0.69.1.crate"
-              ],
-              "strip_prefix": "bindgen-cli-0.69.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty:BUILD.bindgen-cli.bazel"
-            }
-          },
-          "cui__thiserror-1.0.50": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/thiserror/1.0.50/download"
-              ],
-              "strip_prefix": "thiserror-1.0.50",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thiserror-1.0.50.bazel"
-            }
-          },
-          "rules_rust_proto__mio-uds-0.6.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/mio-uds/0.6.8/download"
-              ],
-              "strip_prefix": "mio-uds-0.6.8",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.mio-uds-0.6.8.bazel"
-            }
-          },
-          "rules_rust_proto__tokio-fs-0.1.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-fs/0.1.7/download"
-              ],
-              "strip_prefix": "tokio-fs-0.1.7",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-fs-0.1.7.bazel"
-            }
-          },
-          "rules_rust_bindgen__linux-raw-sys-0.3.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
-              ],
-              "strip_prefix": "linux-raw-sys-0.3.8",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__regex-automata-0.3.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/regex-automata/0.3.3/download"
-              ],
-              "strip_prefix": "regex-automata-0.3.3",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
-            }
-          },
-          "cui__typenum-1.16.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/typenum/1.16.0/download"
-              ],
-              "strip_prefix": "typenum-1.16.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.typenum-1.16.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__rand-0.8.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand/0.8.5/download"
-              ],
-              "strip_prefix": "rand-0.8.5",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand-0.8.5.bazel"
-            }
-          },
-          "cui__time-0.3.36": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/time/0.3.36/download"
-              ],
-              "strip_prefix": "time-0.3.36",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-0.3.36.bazel"
-            }
-          },
-          "cui__errno-0.3.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/errno/0.3.1/download"
-              ],
-              "strip_prefix": "errno-0.3.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.errno-0.3.1.bazel"
-            }
-          },
-          "cui__num-rational-0.1.42": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/num-rational/0.1.42/download"
-              ],
-              "strip_prefix": "num-rational-0.1.42",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-rational-0.1.42.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__difflib-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/difflib/0.4.0/download"
-              ],
-              "strip_prefix": "difflib-0.4.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.difflib-0.4.0.bazel"
-            }
-          },
-          "cui__sha2-0.10.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/sha2/0.10.8/download"
-              ],
-              "strip_prefix": "sha2-0.10.8",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sha2-0.10.8.bazel"
-            }
-          },
-          "cui__clru-0.6.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/clru/0.6.1/download"
-              ],
-              "strip_prefix": "clru-0.6.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clru-0.6.1.bazel"
-            }
-          },
-          "cui__rand-0.4.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand/0.4.6/download"
-              ],
-              "strip_prefix": "rand-0.4.6",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand-0.4.6.bazel"
-            }
-          },
-          "rrra__io-lifetimes-1.0.11": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
-              ],
-              "strip_prefix": "io-lifetimes-1.0.11",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
-            }
-          },
-          "cui__phf_shared-0.11.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/phf_shared/0.11.2/download"
-              ],
-              "strip_prefix": "phf_shared-0.11.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf_shared-0.11.2.bazel"
-            }
-          },
-          "rrra__bitflags-1.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bitflags/1.3.2/download"
-              ],
-              "strip_prefix": "bitflags-1.3.2",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
-            }
-          },
-          "rules_rust_prost__redox_syscall-0.3.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
-              ],
-              "strip_prefix": "redox_syscall-0.3.5",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
-            }
-          },
-          "cui__gix-packetline-blocking-0.16.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7d8395f7501c84d6a1fe902035fdfd8cd86d89e2dd6be0200ec1a72fd3c92d39",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-packetline-blocking/0.16.6/download"
-              ],
-              "strip_prefix": "gix-packetline-blocking-0.16.6",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-packetline-blocking-0.16.6.bazel"
-            }
-          },
-          "rules_rust_proto__fnv-1.0.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/fnv/1.0.7/download"
-              ],
-              "strip_prefix": "fnv-1.0.7",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
-            }
-          },
-          "cui__windows_aarch64_gnullvm-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
-              ],
-              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
-            }
-          },
-          "rules_rust_prost__tracing-core-0.1.31": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tracing-core/0.1.31/download"
-              ],
-              "strip_prefix": "tracing-core-0.1.31",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-core-0.1.31.bazel"
-            }
-          },
-          "rrra__env_logger-0.10.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/env_logger/0.10.0/download"
-              ],
-              "strip_prefix": "env_logger-0.10.0",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.env_logger-0.10.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__aho-corasick-1.0.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
-              ],
-              "strip_prefix": "aho-corasick-1.0.2",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
-            }
-          },
-          "rules_rust_proto__grpc-0.6.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2aaf1d741fe6f3413f1f9f71b99f5e4e26776d563475a8a53ce53a73a8534c1d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/grpc/0.6.2/download"
-              ],
-              "strip_prefix": "grpc-0.6.2",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.grpc-0.6.2.bazel"
-            }
-          },
-          "rules_rust_bindgen__unicode-ident-1.0.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/unicode-ident/1.0.9/download"
-              ],
-              "strip_prefix": "unicode-ident-1.0.9",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.9.bazel"
-            }
-          },
-          "rules_rust_prost__log-0.4.19": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/log/0.4.19/download"
-              ],
-              "strip_prefix": "log-0.4.19",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.log-0.4.19.bazel"
-            }
-          },
-          "cui__ucd-trie-0.1.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/ucd-trie/0.1.6/download"
-              ],
-              "strip_prefix": "ucd-trie-0.1.6",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ucd-trie-0.1.6.bazel"
-            }
-          },
-          "cui__gix-pack-0.43.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7536203a45b31e1bc5694bbf90ba8da1b736c77040dd6a520db369f371eb1ab3",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-pack/0.43.0/download"
-              ],
-              "strip_prefix": "gix-pack-0.43.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-pack-0.43.0.bazel"
-            }
-          },
-          "rules_rust_prost__prettyplease-0.1.25": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/prettyplease/0.1.25/download"
-              ],
-              "strip_prefix": "prettyplease-0.1.25",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prettyplease-0.1.25.bazel"
-            }
-          },
-          "cui__toml-0.7.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/toml/0.7.6/download"
-              ],
-              "strip_prefix": "toml-0.7.6",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml-0.7.6.bazel"
-            }
-          },
-          "rules_rust_prost__tempfile-3.6.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tempfile/3.6.0/download"
-              ],
-              "strip_prefix": "tempfile-3.6.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tempfile-3.6.0.bazel"
-            }
-          },
-          "rules_rust_prost__tokio-stream-0.1.14": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-stream/0.1.14/download"
-              ],
-              "strip_prefix": "tokio-stream-0.1.14",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-stream-0.1.14.bazel"
-            }
-          },
-          "cui__unic-ucd-segment-0.9.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/unic-ucd-segment/0.9.0/download"
-              ],
-              "strip_prefix": "unic-ucd-segment-0.9.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-ucd-segment-0.9.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__android-tzdata-0.1.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
-              ],
-              "strip_prefix": "android-tzdata-0.1.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
-            }
-          },
-          "generated_inputs_in_external_repo": {
-            "bzlFile": "@@rules_rust~//test/generated_inputs:external_repo.bzl",
-            "ruleClassName": "_generated_inputs_in_external_repo",
-            "attributes": {}
-          },
-          "cui__gix-submodule-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "dd0150e82e9282d3f2ab2dd57a22f9f6c3447b9d9856e5321ac92d38e3e0e2b7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-submodule/0.4.0/download"
-              ],
-              "strip_prefix": "gix-submodule-0.4.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-submodule-0.4.0.bazel"
-            }
-          },
-          "cui__serde_spanned-0.6.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/serde_spanned/0.6.5/download"
-              ],
-              "strip_prefix": "serde_spanned-0.6.5",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_spanned-0.6.5.bazel"
-            }
-          },
-          "rules_rust_proto__kernel32-sys-0.2.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/kernel32-sys/0.2.2/download"
-              ],
-              "strip_prefix": "kernel32-sys-0.2.2",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.kernel32-sys-0.2.2.bazel"
-            }
-          },
-          "rules_rust_prost__mime-0.3.17": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/mime/0.3.17/download"
-              ],
-              "strip_prefix": "mime-0.3.17",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.mime-0.3.17.bazel"
-            }
-          },
-          "cui__gix-quote-0.4.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "475c86a97dd0127ba4465fbb239abac9ea10e68301470c9791a6dd5351cdc905",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-quote/0.4.7/download"
-              ],
-              "strip_prefix": "gix-quote-0.4.7",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-quote-0.4.7.bazel"
-            }
-          },
-          "rrra__linux-raw-sys-0.3.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
-              ],
-              "strip_prefix": "linux-raw-sys-0.3.8",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
-            }
-          },
-          "cui__memmap2-0.7.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/memmap2/0.7.1/download"
-              ],
-              "strip_prefix": "memmap2-0.7.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memmap2-0.7.1.bazel"
-            }
-          },
-          "rules_rust_proto__tokio-reactor-0.1.12": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-reactor/0.1.12/download"
-              ],
-              "strip_prefix": "tokio-reactor-0.1.12",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-reactor-0.1.12.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__equivalent-1.0.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/equivalent/1.0.1/download"
-              ],
-              "strip_prefix": "equivalent-1.0.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__fallible-iterator-0.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/fallible-iterator/0.2.0/download"
-              ],
-              "strip_prefix": "fallible-iterator-0.2.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.fallible-iterator-0.2.0.bazel"
-            }
-          },
-          "cui__pest_derive-2.7.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/pest_derive/2.7.0/download"
-              ],
-              "strip_prefix": "pest_derive-2.7.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_derive-2.7.0.bazel"
-            }
-          },
-          "rules_rust_prost__once_cell-1.18.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/once_cell/1.18.0/download"
-              ],
-              "strip_prefix": "once_cell-1.18.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
-            }
-          },
-          "rules_rust_proto__fuchsia-zircon-0.3.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/fuchsia-zircon/0.3.3/download"
-              ],
-              "strip_prefix": "fuchsia-zircon-0.3.3",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-0.3.3.bazel"
-            }
-          },
-          "cui__hermit-abi-0.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
-              ],
-              "strip_prefix": "hermit-abi-0.3.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__regex-syntax-0.7.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
-              ],
-              "strip_prefix": "regex-syntax-0.7.4",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
-            }
-          },
-          "rules_rust_bindgen__errno-dragonfly-0.1.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
-              ],
-              "strip_prefix": "errno-dragonfly-0.1.2",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__miniz_oxide-0.7.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
-              ],
-              "strip_prefix": "miniz_oxide-0.7.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
-            }
-          },
-          "rules_rust_bindgen__windows_x86_64_gnullvm-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
-              ],
-              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__syn-2.0.18": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/syn/2.0.18/download"
-              ],
-              "strip_prefix": "syn-2.0.18",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.syn-2.0.18.bazel"
-            }
-          },
-          "rules_rust_proto__tokio-io-0.1.13": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-io/0.1.13/download"
-              ],
-              "strip_prefix": "tokio-io-0.1.13",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-io-0.1.13.bazel"
-            }
-          },
-          "cui__gix-utils-0.1.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b85d89dc728613e26e0ed952a19583744e7f5240fcd4aa30d6c824ffd8b52f0f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-utils/0.1.5/download"
-              ],
-              "strip_prefix": "gix-utils-0.1.5",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-utils-0.1.5.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__unicase-2.6.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/unicase/2.6.0/download"
-              ],
-              "strip_prefix": "unicase-2.6.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicase-2.6.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__cc-1.0.79": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/cc/1.0.79/download"
-              ],
-              "strip_prefix": "cc-1.0.79",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.cc-1.0.79.bazel"
-            }
-          },
-          "rrra__unicode-ident-1.0.10": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
-              ],
-              "strip_prefix": "unicode-ident-1.0.10",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
-            }
-          },
-          "rules_rust_proto__crossbeam-epoch-0.8.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/crossbeam-epoch/0.8.2/download"
-              ],
-              "strip_prefix": "crossbeam-epoch-0.8.2",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-epoch-0.8.2.bazel"
-            }
-          },
-          "cui__clap_lex-0.5.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/clap_lex/0.5.0/download"
-              ],
-              "strip_prefix": "clap_lex-0.5.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
-            }
-          },
-          "cui__indexmap-2.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/indexmap/2.1.0/download"
-              ],
-              "strip_prefix": "indexmap-2.1.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.indexmap-2.1.0.bazel"
-            }
-          },
-          "cui__hex-0.4.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/hex/0.4.3/download"
-              ],
-              "strip_prefix": "hex-0.4.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hex-0.4.3.bazel"
-            }
-          },
-          "rules_rust_prost__quote-1.0.28": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/quote/1.0.28/download"
-              ],
-              "strip_prefix": "quote-1.0.28",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.quote-1.0.28.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__windows-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows/0.48.0/download"
-              ],
-              "strip_prefix": "windows-0.48.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-0.48.0.bazel"
-            }
-          },
-          "rules_rust_proto__bitflags-1.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bitflags/1.3.2/download"
-              ],
-              "strip_prefix": "bitflags-1.3.2",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__unicode-normalization-0.1.22": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
-              ],
-              "strip_prefix": "unicode-normalization-0.1.22",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
-            }
-          },
-          "cargo_bazel.buildifier-linux-arm64": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v7.1.1/buildifier-linux-arm64"
-              ],
-              "integrity": "sha256-HZrx9pVqQ5/KKHii+/dguXyl3wD2aeXRlTvrDEYHrHE=",
-              "downloaded_file_path": "buildifier",
-              "executable": true
-            }
-          },
-          "rules_rust_wasm_bindgen__anyhow-1.0.71": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anyhow/1.0.71/download"
-              ],
-              "strip_prefix": "anyhow-1.0.71",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
-            }
-          },
-          "rules_rust_bindgen__memchr-2.5.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/memchr/2.5.0/download"
-              ],
-              "strip_prefix": "memchr-2.5.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
-            }
-          },
-          "rules_rust_prost__parking_lot_core-0.9.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/parking_lot_core/0.9.8/download"
-              ],
-              "strip_prefix": "parking_lot_core-0.9.8",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.parking_lot_core-0.9.8.bazel"
-            }
-          },
-          "rules_rust_proto__bytes-0.4.12": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bytes/0.4.12/download"
-              ],
-              "strip_prefix": "bytes-0.4.12",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.bytes-0.4.12.bazel"
-            }
-          },
-          "cui__iana-time-zone-0.1.57": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
-              ],
-              "strip_prefix": "iana-time-zone-0.1.57",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
-            }
-          },
-          "cui__toml_edit-0.19.13": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5f8751d9c1b03c6500c387e96f81f815a4f8e72d142d2d4a9ffa6fedd51ddee7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/toml_edit/0.19.13/download"
-              ],
-              "strip_prefix": "toml_edit-0.19.13",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_edit-0.19.13.bazel"
-            }
-          },
-          "rules_rust_prost__matchit-0.7.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/matchit/0.7.0/download"
-              ],
-              "strip_prefix": "matchit-0.7.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.matchit-0.7.0.bazel"
-            }
-          },
-          "cui__gix-chunk-0.4.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5b42ea64420f7994000130328f3c7a2038f639120518870436d31b8bde704493",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-chunk/0.4.4/download"
-              ],
-              "strip_prefix": "gix-chunk-0.4.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-chunk-0.4.4.bazel"
-            }
-          },
-          "rules_rust_prost__sync_wrapper-0.1.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/sync_wrapper/0.1.2/download"
-              ],
-              "strip_prefix": "sync_wrapper-0.1.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-0.1.2.bazel"
-            }
-          },
-          "cui__wasm-bindgen-macro-support-0.2.87": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.87/download"
-              ],
-              "strip_prefix": "wasm-bindgen-macro-support-0.2.87",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.87.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__errno-dragonfly-0.1.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
-              ],
-              "strip_prefix": "errno-dragonfly-0.1.2",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
-            }
-          },
-          "rules_rust_prost__hyper-timeout-0.4.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/hyper-timeout/0.4.1/download"
-              ],
-              "strip_prefix": "hyper-timeout-0.4.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-timeout-0.4.1.bazel"
-            }
-          },
-          "rules_rust_bindgen__rustc-hash-1.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
-              ],
-              "strip_prefix": "rustc-hash-1.1.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
-            }
-          },
-          "rules_rust_prost__http-0.2.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/http/0.2.9/download"
-              ],
-              "strip_prefix": "http-0.2.9",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-0.2.9.bazel"
-            }
-          },
-          "cui__crossbeam-epoch-0.9.15": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/crossbeam-epoch/0.9.15/download"
-              ],
-              "strip_prefix": "crossbeam-epoch-0.9.15",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-epoch-0.9.15.bazel"
-            }
-          },
-          "cui__gix-config-value-0.14.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ea7505b97f4d8e7933e29735a568ba2f86d8de466669d9f0e8321384f9972f47",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-config-value/0.14.0/download"
-              ],
-              "strip_prefix": "gix-config-value-0.14.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-config-value-0.14.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__chrono-0.4.26": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/chrono/0.4.26/download"
-              ],
-              "strip_prefix": "chrono-0.4.26",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
-            }
-          },
-          "cui__same-file-1.0.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/same-file/1.0.6/download"
-              ],
-              "strip_prefix": "same-file-1.0.6",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.same-file-1.0.6.bazel"
-            }
-          },
-          "cui__linux-raw-sys-0.3.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
-              ],
-              "strip_prefix": "linux-raw-sys-0.3.8",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
-            }
-          },
-          "rules_rust_bindgen__termcolor-1.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/termcolor/1.2.0/download"
-              ],
-              "strip_prefix": "termcolor-1.2.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__rand_core-0.6.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand_core/0.6.4/download"
-              ],
-              "strip_prefix": "rand_core-0.6.4",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
-            }
-          },
-          "cui__crossbeam-channel-0.5.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
-              ],
-              "strip_prefix": "crossbeam-channel-0.5.8",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
-            }
-          },
-          "cui__cc-1.0.79": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/cc/1.0.79/download"
-              ],
-              "strip_prefix": "cc-1.0.79",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cc-1.0.79.bazel"
-            }
-          },
-          "rules_rust_prost__rand-0.8.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand/0.8.5/download"
-              ],
-              "strip_prefix": "rand-0.8.5",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand-0.8.5.bazel"
-            }
-          },
-          "cui__gix-validate-0.8.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e05cab2b03a45b866156e052aa38619f4ece4adcb2f79978bfc249bc3b21b8c5",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-validate/0.8.0/download"
-              ],
-              "strip_prefix": "gix-validate-0.8.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-validate-0.8.0.bazel"
-            }
-          },
-          "rules_rust_prost__anyhow-1.0.71": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anyhow/1.0.71/download"
-              ],
-              "strip_prefix": "anyhow-1.0.71",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
-            }
-          },
-          "cui__is-terminal-0.4.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/is-terminal/0.4.7/download"
-              ],
-              "strip_prefix": "is-terminal-0.4.7",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
-            }
-          },
-          "cui__unicode-width-0.1.10": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/unicode-width/0.1.10/download"
-              ],
-              "strip_prefix": "unicode-width-0.1.10",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-width-0.1.10.bazel"
-            }
-          },
-          "rrra__humantime-2.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/humantime/2.1.0/download"
-              ],
-              "strip_prefix": "humantime-2.1.0",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__libc-0.2.150": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/libc/0.2.150/download"
-              ],
-              "strip_prefix": "libc-0.2.150",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.libc-0.2.150.bazel"
-            }
-          },
-          "rules_rust_bindgen__env_logger-0.10.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/env_logger/0.10.0/download"
-              ],
-              "strip_prefix": "env_logger-0.10.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.env_logger-0.10.0.bazel"
-            }
-          },
-          "cui__toml-0.8.10": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/toml/0.8.10/download"
-              ],
-              "strip_prefix": "toml-0.8.10",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml-0.8.10.bazel"
-            }
-          },
-          "rules_rust_prost__tracing-attributes-0.1.26": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tracing-attributes/0.1.26/download"
-              ],
-              "strip_prefix": "tracing-attributes-0.1.26",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-attributes-0.1.26.bazel"
-            }
-          },
-          "rules_rust_prost__instant-0.1.12": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/instant/0.1.12/download"
-              ],
-              "strip_prefix": "instant-0.1.12",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.instant-0.1.12.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__indexmap-2.0.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/indexmap/2.0.0/download"
-              ],
-              "strip_prefix": "indexmap-2.0.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.indexmap-2.0.0.bazel"
-            }
-          },
-          "cui__windows_i686_gnu-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
-              ],
-              "strip_prefix": "windows_i686_gnu-0.48.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
-            }
-          },
-          "rrra__proc-macro2-1.0.64": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
-              ],
-              "strip_prefix": "proc-macro2-1.0.64",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__predicates-tree-1.0.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/predicates-tree/1.0.9/download"
-              ],
-              "strip_prefix": "predicates-tree-1.0.9",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-tree-1.0.9.bazel"
-            }
-          },
-          "rrra__errno-0.3.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/errno/0.3.1/download"
-              ],
-              "strip_prefix": "errno-0.3.1",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.errno-0.3.1.bazel"
-            }
-          },
-          "cui__num_threads-0.1.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/num_threads/0.1.6/download"
-              ],
-              "strip_prefix": "num_threads-0.1.6",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num_threads-0.1.6.bazel"
-            }
-          },
-          "cui__arc-swap-1.6.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/arc-swap/1.6.0/download"
-              ],
-              "strip_prefix": "arc-swap-1.6.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.arc-swap-1.6.0.bazel"
-            }
-          },
-          "rules_rust_proto__tokio-uds-0.2.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-uds/0.2.7/download"
-              ],
-              "strip_prefix": "tokio-uds-0.2.7",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.2.7.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__webpki-roots-0.25.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/webpki-roots/0.25.2/download"
-              ],
-              "strip_prefix": "webpki-roots-0.25.2",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.webpki-roots-0.25.2.bazel"
-            }
-          },
-          "cui__gix-features-0.35.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9b9ff423ae4983f762659040d13dd7a5defbd54b6a04ac3cc7347741cec828cd",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-features/0.35.0/download"
-              ],
-              "strip_prefix": "gix-features-0.35.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-features-0.35.0.bazel"
-            }
-          },
-          "cui__lock_api-0.4.11": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/lock_api/0.4.11/download"
-              ],
-              "strip_prefix": "lock_api-0.4.11",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.lock_api-0.4.11.bazel"
-            }
-          },
-          "cui__android-tzdata-0.1.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
-              ],
-              "strip_prefix": "android-tzdata-0.1.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
-              ],
-              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
-            }
-          },
-          "rules_rust_prost__futures-task-0.3.28": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/futures-task/0.3.28/download"
-              ],
-              "strip_prefix": "futures-task-0.3.28",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-task-0.3.28.bazel"
-            }
-          },
-          "cui__serde-1.0.190": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/serde/1.0.190/download"
-              ],
-              "strip_prefix": "serde-1.0.190",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde-1.0.190.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__ascii-1.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/ascii/1.1.0/download"
-              ],
-              "strip_prefix": "ascii-1.1.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ascii-1.1.0.bazel"
-            }
-          },
-          "rules_rust_prost__prost-types-0.11.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/prost-types/0.11.9/download"
-              ],
-              "strip_prefix": "prost-types-0.11.9",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-types-0.11.9.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__bstr-0.2.17": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bstr/0.2.17/download"
-              ],
-              "strip_prefix": "bstr-0.2.17",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bstr-0.2.17.bazel"
-            }
-          },
-          "rules_rust_proto__rustc_version-0.2.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rustc_version/0.2.3/download"
-              ],
-              "strip_prefix": "rustc_version-0.2.3",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.rustc_version-0.2.3.bazel"
-            }
-          },
-          "cui__aho-corasick-1.0.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
-              ],
-              "strip_prefix": "aho-corasick-1.0.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__tinyvec-1.6.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tinyvec/1.6.0/download"
-              ],
-              "strip_prefix": "tinyvec-1.6.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__windows_x86_64_msvc-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
-              ],
-              "strip_prefix": "windows_x86_64_msvc-0.48.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
-            }
-          },
-          "rules_rust_proto__winapi-x86_64-pc-windows-gnu-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
-              ],
-              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
-            }
-          },
-          "cui__winnow-0.5.18": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winnow/0.5.18/download"
-              ],
-              "strip_prefix": "winnow-0.5.18",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winnow-0.5.18.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__crossbeam-utils-0.8.16": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
-              ],
-              "strip_prefix": "crossbeam-utils-0.8.16",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
-            }
-          },
-          "cui__memchr-2.6.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/memchr/2.6.4/download"
-              ],
-              "strip_prefix": "memchr-2.6.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memchr-2.6.4.bazel"
-            }
-          },
-          "rrra__serde_derive-1.0.171": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/serde_derive/1.0.171/download"
-              ],
-              "strip_prefix": "serde_derive-1.0.171",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
-            }
-          },
-          "cui__bitflags-2.4.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bitflags/2.4.1/download"
-              ],
-              "strip_prefix": "bitflags-2.4.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bitflags-2.4.1.bazel"
-            }
-          },
-          "rrra__windows_aarch64_gnullvm-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
-              ],
-              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
-            }
-          },
-          "rules_rust_prost__pin-project-lite-0.2.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/pin-project-lite/0.2.9/download"
-              ],
-              "strip_prefix": "pin-project-lite-0.2.9",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-lite-0.2.9.bazel"
-            }
-          },
-          "rules_rust_proto__void-1.0.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/void/1.0.2/download"
-              ],
-              "strip_prefix": "void-1.0.2",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.void-1.0.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ca821da8c1ae6c87c5e94493939a206daa8587caff227c6032e0061a3d80817f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-cli-support/0.2.92/download"
-              ],
-              "strip_prefix": "wasm-bindgen-cli-support-0.2.92",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-cli-support-0.2.92.bazel"
-            }
-          },
-          "rules_rust_prost__regex-syntax-0.7.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/regex-syntax/0.7.2/download"
-              ],
-              "strip_prefix": "regex-syntax-0.7.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-syntax-0.7.2.bazel"
-            }
-          },
-          "cui__pest_generator-2.7.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/pest_generator/2.7.0/download"
-              ],
-              "strip_prefix": "pest_generator-2.7.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_generator-2.7.0.bazel"
-            }
-          },
-          "cui__chrono-tz-0.8.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e23185c0e21df6ed832a12e2bda87c7d1def6842881fb634a8511ced741b0d76",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/chrono-tz/0.8.4/download"
-              ],
-              "strip_prefix": "chrono-tz-0.8.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.chrono-tz-0.8.4.bazel"
-            }
-          },
-          "rules_rust_prost__heck": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/heck/heck-0.4.1.crate"
-              ],
-              "strip_prefix": "heck-0.4.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.heck-0.4.1.bazel"
-            }
-          },
-          "rules_rust_prost__prost-build-0.11.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/prost-build/0.11.9/download"
-              ],
-              "strip_prefix": "prost-build-0.11.9",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-build-0.11.9.bazel"
-            }
-          },
-          "cui__gix-discover-0.25.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "69507643d75a0ea9a402fcf73ced517d2b95cc95385904ac09d03e0b952fde33",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-discover/0.25.0/download"
-              ],
-              "strip_prefix": "gix-discover-0.25.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-discover-0.25.0.bazel"
-            }
-          },
-          "rules_rust_proto__libc-0.2.139": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/libc/0.2.139/download"
-              ],
-              "strip_prefix": "libc-0.2.139",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.libc-0.2.139.bazel"
-            }
-          },
-          "cui__unic-common-0.9.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/unic-common/0.9.0/download"
-              ],
-              "strip_prefix": "unic-common-0.9.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-common-0.9.0.bazel"
-            }
-          },
-          "rules_rust_prost__tower-0.4.13": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tower/0.4.13/download"
-              ],
-              "strip_prefix": "tower-0.4.13",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-0.4.13.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__bitflags-1.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bitflags/1.3.2/download"
-              ],
-              "strip_prefix": "bitflags-1.3.2",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
-            }
-          },
-          "cui__utf8parse-0.2.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/utf8parse/0.2.1/download"
-              ],
-              "strip_prefix": "utf8parse-0.2.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
-            }
-          },
-          "rules_rust_tinyjson": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a",
-              "url": "https://static.crates.io/crates/tinyjson/tinyjson-2.5.1.crate",
-              "strip_prefix": "tinyjson-2.5.1",
-              "type": "tar.gz",
-              "build_file": "@@rules_rust~//util/process_wrapper:BUILD.tinyjson.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__bumpalo-3.13.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bumpalo/3.13.0/download"
-              ],
-              "strip_prefix": "bumpalo-3.13.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
-            }
-          },
-          "cui__pin-project-lite-0.2.13": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/pin-project-lite/0.2.13/download"
-              ],
-              "strip_prefix": "pin-project-lite-0.2.13",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pin-project-lite-0.2.13.bazel"
-            }
-          },
-          "cui__generic-array-0.14.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/generic-array/0.14.7/download"
-              ],
-              "strip_prefix": "generic-array-0.14.7",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.generic-array-0.14.7.bazel"
-            }
-          },
-          "rules_rust_proto__tokio-codec-0.1.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-codec/0.1.2/download"
-              ],
-              "strip_prefix": "tokio-codec-0.1.2",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-codec-0.1.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__ureq-2.8.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/ureq/2.8.0/download"
-              ],
-              "strip_prefix": "ureq-2.8.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ureq-2.8.0.bazel"
-            }
-          },
-          "cui__parking_lot_core-0.9.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/parking_lot_core/0.9.9/download"
-              ],
-              "strip_prefix": "parking_lot_core-0.9.9",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.parking_lot_core-0.9.9.bazel"
-            }
-          },
-          "cui__core-foundation-sys-0.8.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
-              ],
-              "strip_prefix": "core-foundation-sys-0.8.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
-            }
-          },
-          "rrra__quote-1.0.29": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/quote/1.0.29/download"
-              ],
-              "strip_prefix": "quote-1.0.29",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.quote-1.0.29.bazel"
-            }
-          },
-          "rules_rust_proto__protobuf-2.8.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "patch_args": [
-                "-p1"
-              ],
-              "patches": [
-                "@@rules_rust~//proto/protobuf/3rdparty/patches:protobuf-2.8.2.patch"
-              ],
-              "sha256": "70731852eec72c56d11226c8a5f96ad5058a3dab73647ca5f7ee351e464f2571",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/protobuf/2.8.2/download"
-              ],
-              "strip_prefix": "protobuf-2.8.2",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.protobuf-2.8.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.92/download"
-              ],
-              "strip_prefix": "wasm-bindgen-shared-0.2.92",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.92.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__httpdate-1.0.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/httpdate/1.0.2/download"
-              ],
-              "strip_prefix": "httpdate-1.0.2",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.httpdate-1.0.2.bazel"
-            }
-          },
-          "cui__gix-object-0.37.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "1e7e19616c67967374137bae83e950e9b518a9ea8a605069bd6716ada357fd6f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-object/0.37.0/download"
-              ],
-              "strip_prefix": "gix-object-0.37.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-object-0.37.0.bazel"
-            }
-          },
-          "cui__crossbeam-queue-0.3.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/crossbeam-queue/0.3.8/download"
-              ],
-              "strip_prefix": "crossbeam-queue-0.3.8",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-queue-0.3.8.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__iana-time-zone-0.1.57": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
-              ],
-              "strip_prefix": "iana-time-zone-0.1.57",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
-            }
-          },
-          "rules_rust_bindgen__winapi-x86_64-pc-windows-gnu-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
-              ],
-              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
-            }
-          },
-          "cui__deunicode-0.4.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/deunicode/0.4.3/download"
-              ],
-              "strip_prefix": "deunicode-0.4.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.deunicode-0.4.3.bazel"
-            }
-          },
-          "cui__wasm-bindgen-macro-0.2.87": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.87/download"
-              ],
-              "strip_prefix": "wasm-bindgen-macro-0.2.87",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.87.bazel"
-            }
-          },
-          "rules_rust_prost__pin-utils-0.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/pin-utils/0.1.0/download"
-              ],
-              "strip_prefix": "pin-utils-0.1.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-utils-0.1.0.bazel"
-            }
-          },
-          "cui__gix-hashtable-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "409268480841ad008e81c17ca5a293393fbf9f2b6c2f85b8ab9de1f0c5176a16",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-hashtable/0.4.0/download"
-              ],
-              "strip_prefix": "gix-hashtable-0.4.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-hashtable-0.4.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__errno-0.3.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/errno/0.3.1/download"
-              ],
-              "strip_prefix": "errno-0.3.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.errno-0.3.1.bazel"
-            }
-          },
-          "cui__fnv-1.0.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/fnv/1.0.7/download"
-              ],
-              "strip_prefix": "fnv-1.0.7",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
-            }
-          },
-          "cui__js-sys-0.3.64": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/js-sys/0.3.64/download"
-              ],
-              "strip_prefix": "js-sys-0.3.64",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.js-sys-0.3.64.bazel"
-            }
-          },
-          "rules_rust_toolchain_test_target_json": {
-            "bzlFile": "@@rules_rust~//test/unit/toolchain:toolchain_test_utils.bzl",
-            "ruleClassName": "rules_rust_toolchain_test_target_json_repository",
-            "attributes": {
-              "target_json": "@@rules_rust~//test/unit/toolchain:toolchain-test-triple.json"
-            }
-          },
-          "rules_rust_bindgen__once_cell-1.18.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/once_cell/1.18.0/download"
-              ],
-              "strip_prefix": "once_cell-1.18.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
-            }
-          },
-          "rules_rust_prost__prost-0.11.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/prost/0.11.9/download"
-              ],
-              "strip_prefix": "prost-0.11.9",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-0.11.9.bazel"
-            }
-          },
-          "rules_rust_proto__slab-0.3.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/slab/0.3.0/download"
-              ],
-              "strip_prefix": "slab-0.3.0",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.slab-0.3.0.bazel"
-            }
-          },
-          "rules_rust_prost__rand_core-0.6.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand_core/0.6.4/download"
-              ],
-              "strip_prefix": "rand_core-0.6.4",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
-            }
-          },
-          "rules_rust_bindgen__bitflags-1.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bitflags/1.3.2/download"
-              ],
-              "strip_prefix": "bitflags-1.3.2",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
-            }
-          },
-          "cui__wasi-0.11.0-wasi-snapshot-preview1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
-              ],
-              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
-            }
-          },
-          "cui__url-2.5.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/url/2.5.2/download"
-              ],
-              "strip_prefix": "url-2.5.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.url-2.5.2.bazel"
-            }
-          },
-          "rules_rust_bindgen__windows_i686_gnu-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
-              ],
-              "strip_prefix": "windows_i686_gnu-0.48.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__alloc-no-stdlib-2.0.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/alloc-no-stdlib/2.0.4/download"
-              ],
-              "strip_prefix": "alloc-no-stdlib-2.0.4",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.alloc-no-stdlib-2.0.4.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__env_logger-0.8.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/env_logger/0.8.4/download"
-              ],
-              "strip_prefix": "env_logger-0.8.4",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.env_logger-0.8.4.bazel"
-            }
-          },
-          "cui__smol_str-0.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/smol_str/0.2.0/download"
-              ],
-              "strip_prefix": "smol_str-0.2.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smol_str-0.2.0.bazel"
-            }
-          },
-          "cui__memoffset-0.9.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/memoffset/0.9.0/download"
-              ],
-              "strip_prefix": "memoffset-0.9.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
-            }
-          },
-          "cui__log-0.4.19": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/log/0.4.19/download"
-              ],
-              "strip_prefix": "log-0.4.19",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.log-0.4.19.bazel"
-            }
-          },
-          "cui__wasm-bindgen-backend-0.2.87": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.87/download"
-              ],
-              "strip_prefix": "wasm-bindgen-backend-0.2.87",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.87.bazel"
-            }
-          },
-          "cui__pest-2.7.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/pest/2.7.0/download"
-              ],
-              "strip_prefix": "pest-2.7.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest-2.7.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__docopt-1.1.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/docopt/1.1.1/download"
-              ],
-              "strip_prefix": "docopt-1.1.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.docopt-1.1.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__rustc-demangle-0.1.23": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rustc-demangle/0.1.23/download"
-              ],
-              "strip_prefix": "rustc-demangle-0.1.23",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustc-demangle-0.1.23.bazel"
-            }
-          },
-          "rules_rust_prost__rand_chacha-0.3.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
-              ],
-              "strip_prefix": "rand_chacha-0.3.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
-            }
-          },
-          "cui__syn-1.0.109": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/syn/1.0.109/download"
-              ],
-              "strip_prefix": "syn-1.0.109",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.syn-1.0.109.bazel"
-            }
-          },
-          "cui__pathdiff-0.2.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/pathdiff/0.2.1/download"
-              ],
-              "strip_prefix": "pathdiff-0.2.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pathdiff-0.2.1.bazel"
-            }
-          },
-          "cargo_bazel.buildifier-linux-amd64": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v7.1.1/buildifier-linux-amd64"
-              ],
-              "integrity": "sha256-VLfyzo8idhz60mRBbpEgVq6chkX1nrZYO4RrSGSh7oM=",
-              "downloaded_file_path": "buildifier",
-              "executable": true
-            }
-          },
-          "rules_rust_wasm_bindgen__either-1.8.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/either/1.8.1/download"
-              ],
-              "strip_prefix": "either-1.8.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.either-1.8.1.bazel"
-            }
-          },
-          "rules_rust_prost__windows_aarch64_msvc-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
-              ],
-              "strip_prefix": "windows_aarch64_msvc-0.48.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__crc32fast-1.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/crc32fast/1.3.2/download"
-              ],
-              "strip_prefix": "crc32fast-1.3.2",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__wasm-bindgen-backend-0.2.92": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.92/download"
-              ],
-              "strip_prefix": "wasm-bindgen-backend-0.2.92",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.92.bazel"
-            }
-          },
-          "cui__encoding_rs-0.8.33": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/encoding_rs/0.8.33/download"
-              ],
-              "strip_prefix": "encoding_rs-0.8.33",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.encoding_rs-0.8.33.bazel"
-            }
-          },
-          "rules_rust_prost__windows_i686_msvc-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
-              ],
-              "strip_prefix": "windows_i686_msvc-0.48.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
-            }
-          },
-          "rules_rust_proto__hermit-abi-0.2.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/hermit-abi/0.2.6/download"
-              ],
-              "strip_prefix": "hermit-abi-0.2.6",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.hermit-abi-0.2.6.bazel"
-            }
-          },
-          "rules_rust_prost__want-0.3.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/want/0.3.1/download"
-              ],
-              "strip_prefix": "want-0.3.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.want-0.3.1.bazel"
-            }
-          },
-          "cui__gix-glob-0.13.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "a9d76e85f11251dcf751d2c5e918a14f562db5be6f727fd24775245653e9b19d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-glob/0.13.0/download"
-              ],
-              "strip_prefix": "gix-glob-0.13.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-glob-0.13.0.bazel"
-            }
-          },
-          "rules_rust_proto__tokio-timer-0.2.13": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-timer/0.2.13/download"
-              ],
-              "strip_prefix": "tokio-timer-0.2.13",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.2.13.bazel"
-            }
-          },
-          "cui__itoa-1.0.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/itoa/1.0.8/download"
-              ],
-              "strip_prefix": "itoa-1.0.8",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
-            }
-          },
-          "rules_rust_proto__cloudabi-0.0.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/cloudabi/0.0.3/download"
-              ],
-              "strip_prefix": "cloudabi-0.0.3",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cloudabi-0.0.3.bazel"
-            }
-          },
-          "cui__serde_json-1.0.108": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/serde_json/1.0.108/download"
-              ],
-              "strip_prefix": "serde_json-1.0.108",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_json-1.0.108.bazel"
-            }
-          },
-          "rules_rust_bindgen__log-0.4.19": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/log/0.4.19/download"
-              ],
-              "strip_prefix": "log-0.4.19",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.log-0.4.19.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__termcolor-1.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/termcolor/1.2.0/download"
-              ],
-              "strip_prefix": "termcolor-1.2.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__hermit-abi-0.1.19": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/hermit-abi/0.1.19/download"
-              ],
-              "strip_prefix": "hermit-abi-0.1.19",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.1.19.bazel"
-            }
-          },
-          "cui__bstr-1.6.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/bstr/1.6.0/download"
-              ],
-              "strip_prefix": "bstr-1.6.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bstr-1.6.0.bazel"
-            }
-          },
-          "cui__gix-diff-0.36.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "788ddb152c388206e81f36bcbb574e7ed7827c27d8fa62227b34edc333d8928c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-diff/0.36.0/download"
-              ],
-              "strip_prefix": "gix-diff-0.36.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-diff-0.36.0.bazel"
-            }
-          },
-          "cui__gix-index-0.25.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f54d63a9d13c13088f41f5a3accbec284e492ac8f4f707fcc307c139622e17b7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-index/0.25.0/download"
-              ],
-              "strip_prefix": "gix-index-0.25.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-index-0.25.0.bazel"
-            }
-          },
-          "rules_rust_prost__windows_i686_gnu-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
-              ],
-              "strip_prefix": "windows_i686_gnu-0.48.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
-            }
-          },
-          "rules_rust_proto__lock_api-0.3.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/lock_api/0.3.4/download"
-              ],
-              "strip_prefix": "lock_api-0.3.4",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.lock_api-0.3.4.bazel"
-            }
-          },
-          "cui__filetime-0.2.22": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/filetime/0.2.22/download"
-              ],
-              "strip_prefix": "filetime-0.2.22",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.filetime-0.2.22.bazel"
-            }
-          },
-          "cui__tracing-log-0.1.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tracing-log/0.1.4/download"
-              ],
-              "strip_prefix": "tracing-log-0.1.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-log-0.1.4.bazel"
-            }
-          },
-          "cui__rustix-0.38.21": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rustix/0.38.21/download"
-              ],
-              "strip_prefix": "rustix-0.38.21",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustix-0.38.21.bazel"
-            }
-          },
-          "cui__indoc-2.0.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/indoc/2.0.4/download"
-              ],
-              "strip_prefix": "indoc-2.0.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.indoc-2.0.4.bazel"
-            }
-          },
-          "cui__unicode-bom-2.0.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/unicode-bom/2.0.2/download"
-              ],
-              "strip_prefix": "unicode-bom-2.0.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-bom-2.0.2.bazel"
-            }
-          },
-          "cui__smallvec-1.11.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/smallvec/1.11.0/download"
-              ],
-              "strip_prefix": "smallvec-1.11.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smallvec-1.11.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__redox_syscall-0.3.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
-              ],
-              "strip_prefix": "redox_syscall-0.3.5",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
-            }
-          },
-          "cui__ignore-0.4.18": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/ignore/0.4.18/download"
-              ],
-              "strip_prefix": "ignore-0.4.18",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ignore-0.4.18.bazel"
-            }
-          },
-          "cui__textwrap-0.16.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/textwrap/0.16.0/download"
-              ],
-              "strip_prefix": "textwrap-0.16.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.textwrap-0.16.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
-              ],
-              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-conventions-0.2.92": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "8c04e3607b810e76768260db3a5f2e8beb477cb089ef8726da85c8eb9bd3b575",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-wasm-conventions/0.2.92/download"
-              ],
-              "strip_prefix": "wasm-bindgen-wasm-conventions-0.2.92",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-conventions-0.2.92.bazel"
-            }
-          },
-          "cui__valuable-0.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/valuable/0.1.0/download"
-              ],
-              "strip_prefix": "valuable-0.1.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.valuable-0.1.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__form_urlencoded-1.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/form_urlencoded/1.2.0/download"
-              ],
-              "strip_prefix": "form_urlencoded-1.2.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.form_urlencoded-1.2.0.bazel"
-            }
-          },
-          "rules_rust_proto__cfg-if-1.0.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/cfg-if/1.0.0/download"
-              ],
-              "strip_prefix": "cfg-if-1.0.0",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
-            }
-          },
-          "rules_rust_proto__tokio-core-0.1.18": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-core/0.1.18/download"
-              ],
-              "strip_prefix": "tokio-core-0.1.18",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-core-0.1.18.bazel"
-            }
-          },
-          "rules_rust_prost__prost-derive-0.11.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/prost-derive/0.11.9/download"
-              ],
-              "strip_prefix": "prost-derive-0.11.9",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-derive-0.11.9.bazel"
-            }
-          },
-          "cui__wasm-bindgen-shared-0.2.87": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.87/download"
-              ],
-              "strip_prefix": "wasm-bindgen-shared-0.2.87",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.87.bazel"
-            }
-          },
-          "rules_rust_proto__crossbeam-utils-0.7.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/crossbeam-utils/0.7.2/download"
-              ],
-              "strip_prefix": "crossbeam-utils-0.7.2",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-utils-0.7.2.bazel"
-            }
-          },
-          "cui__spectral-0.6.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/spectral/0.6.0/download"
-              ],
-              "strip_prefix": "spectral-0.6.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.spectral-0.6.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__float-cmp-0.8.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/float-cmp/0.8.0/download"
-              ],
-              "strip_prefix": "float-cmp-0.8.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.float-cmp-0.8.0.bazel"
-            }
-          },
-          "cui__gix-tempfile-10.0.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5ae0978f3e11dc57290ee75ac2477c815bca1ce2fa7ed5dc5f16db067410ac4d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-tempfile/10.0.0/download"
-              ],
-              "strip_prefix": "gix-tempfile-10.0.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-tempfile-10.0.0.bazel"
-            }
-          },
-          "rules_rust_prost__tower-layer-0.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tower-layer/0.3.2/download"
-              ],
-              "strip_prefix": "tower-layer-0.3.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-layer-0.3.2.bazel"
-            }
-          },
-          "cui__cfg-expr-0.15.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/cfg-expr/0.15.5/download"
-              ],
-              "strip_prefix": "cfg-expr-0.15.5",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cfg-expr-0.15.5.bazel"
-            }
-          },
-          "cui__prodash-26.2.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/prodash/26.2.2/download"
-              ],
-              "strip_prefix": "prodash-26.2.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.prodash-26.2.2.bazel"
-            }
-          },
-          "cui__winapi-i686-pc-windows-gnu-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
-              ],
-              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
-            }
-          },
-          "cui__gix-0.54.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ad6d32e74454459690d57d18ea4ebec1629936e6b130b51d12cb4a81630ac953",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix/0.54.1/download"
-              ],
-              "strip_prefix": "gix-0.54.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-0.54.1.bazel"
-            }
-          },
-          "cui__gix-command-0.2.10": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "3c576cfbf577f72c097b5f88aedea502cd62952bdc1fb3adcab4531d5525a4c7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-command/0.2.10/download"
-              ],
-              "strip_prefix": "gix-command-0.2.10",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-command-0.2.10.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__tinyvec_macros-0.1.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
-              ],
-              "strip_prefix": "tinyvec_macros-0.1.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
-            }
-          },
-          "cui__gix-odb-0.53.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "8d6a392c6ba3a2f133cdc63120e9bc7aec81eef763db372c817de31febfe64bf",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-odb/0.53.0/download"
-              ],
-              "strip_prefix": "gix-odb-0.53.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-odb-0.53.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__rustix-0.37.20": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rustix/0.37.20/download"
-              ],
-              "strip_prefix": "rustix-0.37.20",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.rustix-0.37.20.bazel"
-            }
-          },
-          "rules_rust_bindgen__windows_i686_msvc-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
-              ],
-              "strip_prefix": "windows_i686_msvc-0.48.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__clap_builder-4.3.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/clap_builder/4.3.3/download"
-              ],
-              "strip_prefix": "clap_builder-4.3.3",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_builder-4.3.3.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen_cli": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "08f61e21873f51e3059a8c7c3eef81ede7513d161cfc60751c7b2ffa6ed28270",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-cli/wasm-bindgen-cli-0.2.92.crate"
-              ],
-              "type": "tar.gz",
-              "strip_prefix": "wasm-bindgen-cli-0.2.92",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty:BUILD.wasm-bindgen-cli.bazel",
-              "patch_args": [
-                "-p1"
-              ],
-              "patches": [
-                "@@rules_rust~//wasm_bindgen/3rdparty/patches:resolver.patch"
-              ]
-            }
-          },
-          "rules_rust_proto__tokio-threadpool-0.1.18": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-threadpool/0.1.18/download"
-              ],
-              "strip_prefix": "tokio-threadpool-0.1.18",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-threadpool-0.1.18.bazel"
-            }
-          },
-          "rules_rust_bindgen__annotate-snippets-0.9.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c3b9d411ecbaf79885c6df4d75fff75858d5995ff25385657a28af47e82f9c36",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/annotate-snippets/0.9.1/download"
-              ],
-              "strip_prefix": "annotate-snippets-0.9.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.annotate-snippets-0.9.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__httparse-1.8.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/httparse/1.8.0/download"
-              ],
-              "strip_prefix": "httparse-1.8.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.httparse-1.8.0.bazel"
-            }
-          },
-          "cui__powerfmt-0.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/powerfmt/0.2.0/download"
-              ],
-              "strip_prefix": "powerfmt-0.2.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.powerfmt-0.2.0.bazel"
-            }
-          },
-          "rrra__strsim-0.10.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/strsim/0.10.0/download"
-              ],
-              "strip_prefix": "strsim-0.10.0",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
-            }
-          },
-          "rules_rust_prost__tonic-0.9.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tonic/0.9.2/download"
-              ],
-              "strip_prefix": "tonic-0.9.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tonic-0.9.2.bazel"
-            }
-          },
-          "rules_rust_prost__async-trait-0.1.68": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/async-trait/0.1.68/download"
-              ],
-              "strip_prefix": "async-trait-0.1.68",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.async-trait-0.1.68.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__brotli-decompressor-2.5.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/brotli-decompressor/2.5.1/download"
-              ],
-              "strip_prefix": "brotli-decompressor-2.5.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.brotli-decompressor-2.5.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__windows_x86_64_msvc-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
-              ],
-              "strip_prefix": "windows_x86_64_msvc-0.48.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
-            }
-          },
-          "cui__unicode-normalization-0.1.22": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
-              ],
-              "strip_prefix": "unicode-normalization-0.1.22",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
-            }
-          },
-          "rules_rust_prost__windows_x86_64_msvc-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
-              ],
-              "strip_prefix": "windows_x86_64_msvc-0.48.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__idna-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/idna/0.4.0/download"
-              ],
-              "strip_prefix": "idna-0.4.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.idna-0.4.0.bazel"
-            }
-          },
-          "rrra__regex-1.9.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/regex/1.9.1/download"
-              ],
-              "strip_prefix": "regex-1.9.1",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-1.9.1.bazel"
-            }
-          },
-          "cui__anstyle-parse-0.2.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
-              ],
-              "strip_prefix": "anstyle-parse-0.2.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__wait-timeout-0.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wait-timeout/0.2.0/download"
-              ],
-              "strip_prefix": "wait-timeout-0.2.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wait-timeout-0.2.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__windows_aarch64_gnullvm-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
-              ],
-              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__quick-error-1.2.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/quick-error/1.2.3/download"
-              ],
-              "strip_prefix": "quick-error-1.2.3",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.quick-error-1.2.3.bazel"
-            }
-          },
-          "rules_rust_bindgen__winapi-0.3.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi/0.3.9/download"
-              ],
-              "strip_prefix": "winapi-0.3.9",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__wasm-bindgen-threads-xform-0.2.92": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2d5add359b7f7d09a55299a9d29be54414264f2b8cf84f8c8fda5be9269b5dd9",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen-threads-xform/0.2.92/download"
-              ],
-              "strip_prefix": "wasm-bindgen-threads-xform-0.2.92",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-threads-xform-0.2.92.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__core-foundation-sys-0.8.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
-              ],
-              "strip_prefix": "core-foundation-sys-0.8.4",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
-            }
-          },
-          "rules_rust_prost__futures-core-0.3.28": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/futures-core/0.3.28/download"
-              ],
-              "strip_prefix": "futures-core-0.3.28",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-core-0.3.28.bazel"
-            }
-          },
-          "rrra__winapi-x86_64-pc-windows-gnu-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
-              ],
-              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
-            }
-          },
-          "rrra__anstyle-1.0.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anstyle/1.0.1/download"
-              ],
-              "strip_prefix": "anstyle-1.0.1",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
-            }
-          },
-          "cui__dunce-1.0.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/dunce/1.0.4/download"
-              ],
-              "strip_prefix": "dunce-1.0.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.dunce-1.0.4.bazel"
-            }
-          },
-          "cui__phf_generator-0.11.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/phf_generator/0.11.2/download"
-              ],
-              "strip_prefix": "phf_generator-0.11.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf_generator-0.11.2.bazel"
-            }
-          },
-          "rules_rust_prost__fastrand-1.9.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/fastrand/1.9.0/download"
-              ],
-              "strip_prefix": "fastrand-1.9.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.fastrand-1.9.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__windows_x86_64_gnu-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
-              ],
-              "strip_prefix": "windows_x86_64_gnu-0.48.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__memoffset-0.9.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/memoffset/0.9.0/download"
-              ],
-              "strip_prefix": "memoffset-0.9.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__windows-targets-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows-targets/0.48.0/download"
-              ],
-              "strip_prefix": "windows-targets-0.48.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-targets-0.48.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__twoway-0.1.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/twoway/0.1.8/download"
-              ],
-              "strip_prefix": "twoway-0.1.8",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.twoway-0.1.8.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__linux-raw-sys-0.3.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
-              ],
-              "strip_prefix": "linux-raw-sys-0.3.8",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
-            }
-          },
-          "cui__quote-1.0.29": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/quote/1.0.29/download"
-              ],
-              "strip_prefix": "quote-1.0.29",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.quote-1.0.29.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__safemem-0.3.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/safemem/0.3.3/download"
-              ],
-              "strip_prefix": "safemem-0.3.3",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__assert_cmd-1.0.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/assert_cmd/1.0.8/download"
-              ],
-              "strip_prefix": "assert_cmd-1.0.8",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.assert_cmd-1.0.8.bazel"
-            }
-          },
-          "cui__serde_starlark-0.1.14": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "29675b116dd4c7ab4012e00e71f6dee9ed8c731108468b4434779c6b9eec7957",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/serde_starlark/0.1.14/download"
-              ],
-              "strip_prefix": "serde_starlark-0.1.14",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_starlark-0.1.14.bazel"
-            }
-          },
-          "cui__ppv-lite86-0.2.17": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
-              ],
-              "strip_prefix": "ppv-lite86-0.2.17",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
-            }
-          },
-          "cui__rand_core-0.6.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand_core/0.6.4/download"
-              ],
-              "strip_prefix": "rand_core-0.6.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
-            }
-          },
-          "rules_rust_prost__wasi-0.11.0-wasi-snapshot-preview1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
-              ],
-              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__rustix-0.37.23": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rustix/0.37.23/download"
-              ],
-              "strip_prefix": "rustix-0.37.23",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
-            }
-          },
-          "rrra__clap_lex-0.5.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/clap_lex/0.5.0/download"
-              ],
-              "strip_prefix": "clap_lex-0.5.0",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
-            }
-          },
-          "rules_rust_prost__base64-0.21.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/base64/0.21.2/download"
-              ],
-              "strip_prefix": "base64-0.21.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.base64-0.21.2.bazel"
-            }
-          },
-          "rules_rust_proto__log-0.3.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/log/0.3.9/download"
-              ],
-              "strip_prefix": "log-0.3.9",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.log-0.3.9.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__windows_i686_msvc-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
-              ],
-              "strip_prefix": "windows_i686_msvc-0.48.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
-            }
-          },
-          "cui__home-0.5.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/home/0.5.5/download"
-              ],
-              "strip_prefix": "home-0.5.5",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.home-0.5.5.bazel"
-            }
-          },
-          "rules_rust_proto__memoffset-0.5.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/memoffset/0.5.6/download"
-              ],
-              "strip_prefix": "memoffset-0.5.6",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.memoffset-0.5.6.bazel"
-            }
-          },
-          "cui__gix-attributes-0.19.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2451665e70709ba4753b623ef97511ee98c4a73816b2c5b5df25678d607ed820",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-attributes/0.19.0/download"
-              ],
-              "strip_prefix": "gix-attributes-0.19.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-attributes-0.19.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__clap-4.3.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/clap/4.3.3/download"
-              ],
-              "strip_prefix": "clap-4.3.3",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap-4.3.3.bazel"
-            }
-          },
-          "rules_rust_prost__hyper-0.14.26": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/hyper/0.14.26/download"
-              ],
-              "strip_prefix": "hyper-0.14.26",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-0.14.26.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__predicates-2.1.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/predicates/2.1.5/download"
-              ],
-              "strip_prefix": "predicates-2.1.5",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-2.1.5.bazel"
-            }
-          },
-          "cui__windows_x86_64_msvc-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
-              ],
-              "strip_prefix": "windows_x86_64_msvc-0.48.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
-            }
-          },
-          "cui__redox_syscall-0.3.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
-              ],
-              "strip_prefix": "redox_syscall-0.3.5",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__indexmap-1.9.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/indexmap/1.9.3/download"
-              ],
-              "strip_prefix": "indexmap-1.9.3",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__once_cell-1.18.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/once_cell/1.18.0/download"
-              ],
-              "strip_prefix": "once_cell-1.18.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__termtree-0.4.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/termtree/0.4.1/download"
-              ],
-              "strip_prefix": "termtree-0.4.1",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.termtree-0.4.1.bazel"
-            }
-          },
-          "rules_rust_bindgen__anstream-0.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anstream/0.3.2/download"
-              ],
-              "strip_prefix": "anstream-0.3.2",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
-            }
-          },
-          "cui__gix-protocol-0.40.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "cc7b700dc20cc9be8a5130a1fd7e10c34117ffa7068431c8c24d963f0a2e0c9b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-protocol/0.40.0/download"
-              ],
-              "strip_prefix": "gix-protocol-0.40.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-protocol-0.40.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__doc-comment-0.3.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/doc-comment/0.3.3/download"
-              ],
-              "strip_prefix": "doc-comment-0.3.3",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.doc-comment-0.3.3.bazel"
-            }
-          },
-          "cui__crc32fast-1.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/crc32fast/1.3.2/download"
-              ],
-              "strip_prefix": "crc32fast-1.3.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
-            }
-          },
-          "rules_rust_bindgen__aho-corasick-1.0.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
-              ],
-              "strip_prefix": "aho-corasick-1.0.2",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__walrus-macro-0.19.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/walrus-macro/0.19.0/download"
-              ],
-              "strip_prefix": "walrus-macro-0.19.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.walrus-macro-0.19.0.bazel"
-            }
-          },
-          "cui__rdrand-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rdrand/0.4.0/download"
-              ],
-              "strip_prefix": "rdrand-0.4.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rdrand-0.4.0.bazel"
-            }
-          },
-          "cui__cpufeatures-0.2.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/cpufeatures/0.2.9/download"
-              ],
-              "strip_prefix": "cpufeatures-0.2.9",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cpufeatures-0.2.9.bazel"
-            }
-          },
-          "rules_rust_prost__mio-0.8.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/mio/0.8.8/download"
-              ],
-              "strip_prefix": "mio-0.8.8",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.mio-0.8.8.bazel"
-            }
-          },
-          "rules_rust_proto__base64-0.9.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/base64/0.9.3/download"
-              ],
-              "strip_prefix": "base64-0.9.3",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.base64-0.9.3.bazel"
-            }
-          },
-          "cui__rustc-serialize-0.3.25": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rustc-serialize/0.3.25/download"
-              ],
-              "strip_prefix": "rustc-serialize-0.3.25",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustc-serialize-0.3.25.bazel"
-            }
-          },
-          "rrra__anyhow-1.0.71": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anyhow/1.0.71/download"
-              ],
-              "strip_prefix": "anyhow-1.0.71",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
-            }
-          },
-          "cui__gix-path-0.10.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "6a1d370115171e3ae03c5c6d4f7d096f2981a40ddccb98dfd704c773530ba73b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-path/0.10.0/download"
-              ],
-              "strip_prefix": "gix-path-0.10.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-path-0.10.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__hermit-abi-0.3.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/hermit-abi/0.3.1/download"
-              ],
-              "strip_prefix": "hermit-abi-0.3.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.hermit-abi-0.3.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__cc-1.0.83": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/cc/1.0.83/download"
-              ],
-              "strip_prefix": "cc-1.0.83",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.cc-1.0.83.bazel"
-            }
-          },
-          "rrra__utf8parse-0.2.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/utf8parse/0.2.1/download"
-              ],
-              "strip_prefix": "utf8parse-0.2.1",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
-            }
-          },
-          "rules_rust_proto__futures-cpupool-0.1.8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/futures-cpupool/0.1.8/download"
-              ],
-              "strip_prefix": "futures-cpupool-0.1.8",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.futures-cpupool-0.1.8.bazel"
-            }
-          },
-          "cargo_bazel.buildifier-windows-amd64.exe": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_file",
-            "attributes": {
-              "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v7.1.1/buildifier-windows-amd64.exe"
-              ],
-              "integrity": "sha256-Mx2IPnyjbIu+KKHoUoqccRAvS+Yj+Tn6PSCk2PAEvqs=",
-              "downloaded_file_path": "buildifier.exe",
-              "executable": true
-            }
-          },
-          "cui__regex-1.10.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/regex/1.10.2/download"
-              ],
-              "strip_prefix": "regex-1.10.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-1.10.2.bazel"
-            }
-          },
-          "rrra__log-0.4.19": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/log/0.4.19/download"
-              ],
-              "strip_prefix": "log-0.4.19",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.log-0.4.19.bazel"
-            }
-          },
-          "cui__cargo_metadata-0.18.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/cargo_metadata/0.18.1/download"
-              ],
-              "strip_prefix": "cargo_metadata-0.18.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo_metadata-0.18.1.bazel"
-            }
-          },
-          "cui__gix-fs-0.7.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "09815faba62fe9b32d918b75a554686c98e43f7d48c43a80df58eb718e5c6635",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-fs/0.7.0/download"
-              ],
-              "strip_prefix": "gix-fs-0.7.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-fs-0.7.0.bazel"
-            }
-          },
-          "cui__gix-sec-0.10.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "92b9542ac025a8c02ed5d17b3fc031a111a384e859d0be3532ec4d58c40a0f28",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-sec/0.10.0/download"
-              ],
-              "strip_prefix": "gix-sec-0.10.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-sec-0.10.0.bazel"
-            }
-          },
-          "cui__gix-trace-0.1.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-trace/0.1.3/download"
-              ],
-              "strip_prefix": "gix-trace-0.1.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-trace-0.1.3.bazel"
-            }
-          },
-          "cui__humansize-2.1.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/humansize/2.1.3/download"
-              ],
-              "strip_prefix": "humansize-2.1.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.humansize-2.1.3.bazel"
-            }
-          },
-          "rules_rust_prost__winapi-x86_64-pc-windows-gnu-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
-              ],
-              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__io-lifetimes-1.0.11": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
-              ],
-              "strip_prefix": "io-lifetimes-1.0.11",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
-            }
-          },
-          "rules_rust_prost__tower-service-0.3.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tower-service/0.3.2/download"
-              ],
-              "strip_prefix": "tower-service-0.3.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-service-0.3.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__diff-0.1.13": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/diff/0.1.13/download"
-              ],
-              "strip_prefix": "diff-0.1.13",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.diff-0.1.13.bazel"
-            }
-          },
-          "cui__rand_core-0.4.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/rand_core/0.4.2/download"
-              ],
-              "strip_prefix": "rand_core-0.4.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_core-0.4.2.bazel"
-            }
-          },
-          "cui__phf-0.11.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/phf/0.11.2/download"
-              ],
-              "strip_prefix": "phf-0.11.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf-0.11.2.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__winapi-0.3.9": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi/0.3.9/download"
-              ],
-              "strip_prefix": "winapi-0.3.9",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
-            }
-          },
-          "cui__wasm-bindgen-0.2.87": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasm-bindgen/0.2.87/download"
-              ],
-              "strip_prefix": "wasm-bindgen-0.2.87",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-0.2.87.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__wasmparser-0.102.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/wasmparser/0.102.0/download"
-              ],
-              "strip_prefix": "wasmparser-0.102.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.102.0.bazel"
-            }
-          },
-          "cui__winapi-x86_64-pc-windows-gnu-0.4.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
-              ],
-              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
-            }
-          },
-          "rules_rust_proto__grpc-compiler-0.6.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "907274ce8ee7b40a0d0b0db09022ea22846a47cfb1fc8ad2c983c70001b4ffb1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/grpc-compiler/0.6.2/download"
-              ],
-              "strip_prefix": "grpc-compiler-0.6.2",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.grpc-compiler-0.6.2.bazel"
-            }
-          },
-          "rrra__heck-0.4.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/heck/0.4.1/download"
-              ],
-              "strip_prefix": "heck-0.4.1",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.heck-0.4.1.bazel"
-            }
-          },
-          "rules_rust_prost__hermit-abi-0.2.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/hermit-abi/0.2.6/download"
-              ],
-              "strip_prefix": "hermit-abi-0.2.6",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hermit-abi-0.2.6.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__autocfg-1.1.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/autocfg/1.1.0/download"
-              ],
-              "strip_prefix": "autocfg-1.1.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
-            }
-          },
-          "cui__version_check-0.9.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/version_check/0.9.4/download"
-              ],
-              "strip_prefix": "version_check-0.9.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
-            }
-          },
-          "cui__gix-date-0.8.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "fc7df669639582dc7c02737642f76890b03b5544e141caba68a7d6b4eb551e0d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-date/0.8.0/download"
-              ],
-              "strip_prefix": "gix-date-0.8.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-date-0.8.0.bazel"
-            }
-          },
-          "cui__scopeguard-1.2.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/scopeguard/1.2.0/download"
-              ],
-              "strip_prefix": "scopeguard-1.2.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__clang-sys-1.6.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/clang-sys/1.6.1/download"
-              ],
-              "strip_prefix": "clang-sys-1.6.1",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clang-sys-1.6.1.bazel"
-            }
-          },
-          "rrra__anstyle-parse-0.2.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
-              ],
-              "strip_prefix": "anstyle-parse-0.2.1",
-              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
-            }
-          },
-          "rules_rust_wasm_bindgen__num_cpus-1.16.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/num_cpus/1.16.0/download"
-              ],
-              "strip_prefix": "num_cpus-1.16.0",
-              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num_cpus-1.16.0.bazel"
-            }
-          },
-          "llvm-raw": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "urls": [
-                "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-project-14.0.6.src.tar.xz"
-              ],
-              "strip_prefix": "llvm-project-14.0.6.src",
-              "sha256": "8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a",
-              "build_file_content": "# empty",
-              "patch_args": [
-                "-p1"
-              ],
-              "patches": [
-                "@@rules_rust~//bindgen/3rdparty/patches:llvm-project.cxx17.patch",
-                "@@rules_rust~//bindgen/3rdparty/patches:llvm-project.incompatible_disallow_empty_glob.patch"
-              ]
-            }
-          },
-          "cui__phf_codegen-0.11.2": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/phf_codegen/0.11.2/download"
-              ],
-              "strip_prefix": "phf_codegen-0.11.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf_codegen-0.11.2.bazel"
-            }
-          },
-          "cui__winapi-util-0.1.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-util/0.1.5/download"
-              ],
-              "strip_prefix": "winapi-util-0.1.5",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
-            }
-          },
-          "rules_rust_proto__tokio-current-thread-0.1.7": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/tokio-current-thread/0.1.7/download"
-              ],
-              "strip_prefix": "tokio-current-thread-0.1.7",
-              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-current-thread-0.1.7.bazel"
-            }
-          },
-          "cui__crossbeam-deque-0.8.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/crossbeam-deque/0.8.3/download"
-              ],
-              "strip_prefix": "crossbeam-deque-0.8.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-deque-0.8.3.bazel"
-            }
-          },
-          "cui__android_system_properties-0.1.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/android_system_properties/0.1.5/download"
-              ],
-              "strip_prefix": "android_system_properties-0.1.5",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.android_system_properties-0.1.5.bazel"
-            }
-          },
           "cui__pest_meta-2.7.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10307,6 +5998,19 @@
               ],
               "strip_prefix": "anstyle-wincon-1.0.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__scopeguard-1.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.2.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.2.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
             }
           },
           "rrra__anstyle-query-1.0.0": {
@@ -10335,19 +6039,6 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
             }
           },
-          "cui__gix-hash-0.13.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "1884c7b41ea0875217c1be9ce91322f90bde433e91d374d0e1276073a51ccc60",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-hash/0.13.1/download"
-              ],
-              "strip_prefix": "gix-hash-0.13.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-hash-0.13.1.bazel"
-            }
-          },
           "cui__maybe-async-0.2.7": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10361,17 +6052,43 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.maybe-async-0.2.7.bazel"
             }
           },
-          "cui__gix-filter-0.5.0": {
+          "cui__regex-automata-0.3.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "1be40d28cd41445bb6cd52c4d847d915900e5466f7433eaee6a9e0a3d1d88b08",
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-filter/0.5.0/download"
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
               ],
-              "strip_prefix": "gix-filter-0.5.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-filter-0.5.0.bazel"
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "rules_rust_prost__regex-syntax-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-syntax-0.8.4.bazel"
+            }
+          },
+          "rrra__windows_aarch64_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__mime-0.3.17": {
@@ -10387,6 +6104,45 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.mime-0.3.17.bazel"
             }
           },
+          "rules_rust_prost__tempfile-3.12.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.12.0/download"
+              ],
+              "strip_prefix": "tempfile-3.12.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tempfile-3.12.0.bazel"
+            }
+          },
+          "cui__regex-automata-0.4.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.8/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-automata-0.4.8.bazel"
+            }
+          },
+          "rrra__anstyle-wincon-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-wincon-1.0.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
+            }
+          },
           "rrra__rustix-0.37.23": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10400,17 +6156,82 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
             }
           },
-          "rules_rust_prost__hermit-abi-0.3.1": {
+          "cui__jiff-tzdb-platform-0.1.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286",
+              "sha256": "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/hermit-abi/0.3.1/download"
+                "https://static.crates.io/crates/jiff-tzdb-platform/0.1.1/download"
               ],
-              "strip_prefix": "hermit-abi-0.3.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hermit-abi-0.3.1.bazel"
+              "strip_prefix": "jiff-tzdb-platform-0.1.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.jiff-tzdb-platform-0.1.1.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-lite-0.2.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-lite/0.2.14/download"
+              ],
+              "strip_prefix": "pin-project-lite-0.2.14",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-lite-0.2.14.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__adler-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__log-0.4.19": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "cui__toml_edit-0.22.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_edit/0.22.22/download"
+              ],
+              "strip_prefix": "toml_edit-0.22.22",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_edit-0.22.22.bazel"
+            }
+          },
+          "rules_rust_prost__hermit-abi-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.9/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.9",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hermit-abi-0.3.9.bazel"
             }
           },
           "cui__maplit-1.0.2": {
@@ -10426,6 +6247,19 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.maplit-1.0.2.bazel"
             }
           },
+          "cui__serde_derive-1.0.210": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.210/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.210",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_derive-1.0.210.bazel"
+            }
+          },
           "rrra__syn-2.0.25": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10439,17 +6273,43 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.syn-2.0.25.bazel"
             }
           },
-          "cui__gix-worktree-0.26.0": {
+          "rules_rust_prost__serde_derive-1.0.209": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "9f5e32972801bd82d56609e6fc84efc358fa1f11f25c5e83b7807ee2280f14fe",
+              "sha256": "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-worktree/0.26.0/download"
+                "https://static.crates.io/crates/serde_derive/1.0.209/download"
               ],
-              "strip_prefix": "gix-worktree-0.26.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-worktree-0.26.0.bazel"
+              "strip_prefix": "serde_derive-1.0.209",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.serde_derive-1.0.209.bazel"
+            }
+          },
+          "cui__digest-0.10.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/digest/0.10.7/download"
+              ],
+              "strip_prefix": "digest-0.10.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.digest-0.10.7.bazel"
+            }
+          },
+          "cui__equivalent-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
             }
           },
           "rules_rust_wasm_bindgen__semver-1.0.17": {
@@ -10465,6 +6325,79 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.semver-1.0.17.bazel"
             }
           },
+          "cui": {
+            "bzlFile": "@@rules_rust~//crate_universe/private:crates_vendor.bzl",
+            "ruleClassName": "crates_vendor_remote_repository",
+            "attributes": {
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bazel",
+              "defs_module": "@@rules_rust~//crate_universe/3rdparty/crates:defs.bzl"
+            }
+          },
+          "cui__gix-bitmap-0.2.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-bitmap/0.2.11/download"
+              ],
+              "strip_prefix": "gix-bitmap-0.2.11",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-bitmap-0.2.11.bazel"
+            }
+          },
+          "cui__gix-prompt-0.8.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "74fde865cdb46b30d8dad1293385d9bcf998d3a39cbf41bee67d0dab026fe6b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-prompt/0.8.7/download"
+              ],
+              "strip_prefix": "gix-prompt-0.8.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-prompt-0.8.7.bazel"
+            }
+          },
+          "cui__proc-macro2-1.0.88": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.88/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.88",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.proc-macro2-1.0.88.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__memchr-2.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.5.0/download"
+              ],
+              "strip_prefix": "memchr-2.5.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
+            }
+          },
+          "rules_rust_prost__regex-automata-0.4.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.7/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.7",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-automata-0.4.7.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__wasmparser-0.80.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10476,6 +6409,45 @@
               ],
               "strip_prefix": "wasmparser-0.80.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.80.2.bazel"
+            }
+          },
+          "rrra__once_cell-1.18.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
+              ],
+              "strip_prefix": "once_cell-1.18.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-tls-api-0.1.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "68d0e040d5b1f4cfca70ec4f371229886a5de5bb554d272a4a8da73004a7b2c9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-tls-api/0.1.22/download"
+              ],
+              "strip_prefix": "tokio-tls-api-0.1.22",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-tls-api-0.1.22.bazel"
+            }
+          },
+          "cui__cargo_toml-0.20.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "88da5a13c620b4ca0078845707ea9c3faf11edbc3ffd8497d11d686211cd1ac0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo_toml/0.20.5/download"
+              ],
+              "strip_prefix": "cargo_toml-0.20.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo_toml-0.20.5.bazel"
             }
           },
           "cui__heck-0.4.1": {
@@ -10491,6 +6463,45 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.heck-0.4.1.bazel"
             }
           },
+          "cui__gix-discover-0.35.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0577366b9567376bc26e815fd74451ebd0e6218814e242f8e5b7072c58d956d2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-discover/0.35.0/download"
+              ],
+              "strip_prefix": "gix-discover-0.35.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-discover-0.35.0.bazel"
+            }
+          },
+          "cui__windows-sys-0.59.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
+            }
+          },
+          "rules_rust_prost__redox_syscall-0.5.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.5.3/download"
+              ],
+              "strip_prefix": "redox_syscall-0.5.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.redox_syscall-0.5.3.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__winapi-x86_64-pc-windows-gnu-0.4.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10502,6 +6513,45 @@
               ],
               "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "cui__autocfg-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "cui__gix-pathspec-0.7.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5d23bf239532b4414d0e63b8ab3a65481881f7237ed9647bb10c1e3cc54c5ceb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-pathspec/0.7.7/download"
+              ],
+              "strip_prefix": "gix-pathspec-0.7.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-pathspec-0.7.7.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
             }
           },
           "libc": {
@@ -10543,6 +6593,84 @@
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.minimal-lexical-0.2.1.bazel"
             }
           },
+          "cui__spdx-0.10.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/spdx/0.10.6/download"
+              ],
+              "strip_prefix": "spdx-0.10.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.spdx-0.10.6.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-build-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-build/0.1.1/download"
+              ],
+              "strip_prefix": "winapi-build-0.1.1",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-build-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__base64-0.13.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.13.1/download"
+              ],
+              "strip_prefix": "base64-0.13.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.base64-0.13.1.bazel"
+            }
+          },
+          "rules_rust_proto__parking_lot-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.9.0/download"
+              ],
+              "strip_prefix": "parking_lot-0.9.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.parking_lot-0.9.0.bazel"
+            }
+          },
+          "cui__gix-hash-0.14.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-hash/0.14.2/download"
+              ],
+              "strip_prefix": "gix-hash-0.14.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-hash-0.14.2.bazel"
+            }
+          },
+          "rules_rust_prost__windows_aarch64_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
           "rrra__regex-automata-0.3.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10556,17 +6684,17 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
             }
           },
-          "cui__spdx-0.10.3": {
+          "rules_rust_bindgen__bindgen-0.70.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "62bde1398b09b9f93fc2fc9b9da86e362693e999d3a54a8ac47a99a5a73f638b",
+              "sha256": "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/spdx/0.10.3/download"
+                "https://static.crates.io/crates/bindgen/0.70.1/download"
               ],
-              "strip_prefix": "spdx-0.10.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.spdx-0.10.3.bazel"
+              "strip_prefix": "bindgen-0.70.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bindgen-0.70.1.bazel"
             }
           },
           "rules_rust_wasm_bindgen__normalize-line-endings-0.3.0": {
@@ -10582,17 +6710,30 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.normalize-line-endings-0.3.0.bazel"
             }
           },
-          "rules_rust_prost__h2-0.3.19": {
+          "rules_rust_prost__prost-build-0.13.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782",
+              "sha256": "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/h2/0.3.19/download"
+                "https://static.crates.io/crates/prost-build/0.13.1/download"
               ],
-              "strip_prefix": "h2-0.3.19",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.h2-0.3.19.bazel"
+              "strip_prefix": "prost-build-0.13.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-build-0.13.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__colorchoice-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.2/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.colorchoice-1.0.2.bazel"
             }
           },
           "rules_rust_wasm_bindgen__wasmparser-0.108.0": {
@@ -10608,17 +6749,56 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.108.0.bazel"
             }
           },
-          "rules_rust_bindgen__colorchoice-1.0.0": {
+          "cui__memmap2-0.9.5": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
+              "sha256": "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/colorchoice/1.0.0/download"
+                "https://static.crates.io/crates/memmap2/0.9.5/download"
               ],
-              "strip_prefix": "colorchoice-1.0.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
+              "strip_prefix": "memmap2-0.9.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memmap2-0.9.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-query-1.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.1.1/download"
+              ],
+              "strip_prefix": "anstyle-query-1.1.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-query-1.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__humantime-2.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand_chacha-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
             }
           },
           "rules_rust_proto__tokio-sync-0.1.8": {
@@ -10634,6 +6814,45 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-sync-0.1.8.bazel"
             }
           },
+          "rules_rust_bindgen__heck-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.5.0/download"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-util-0.7.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-util/0.7.11/download"
+              ],
+              "strip_prefix": "tokio-util-0.7.11",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-util-0.7.11.bazel"
+            }
+          },
+          "cui__hashbrown-0.15.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.15.0/download"
+              ],
+              "strip_prefix": "hashbrown-0.15.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hashbrown-0.15.0.bazel"
+            }
+          },
           "rules_rust_bindgen__nom-7.1.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10645,6 +6864,32 @@
               ],
               "strip_prefix": "nom-7.1.3",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.nom-7.1.3.bazel"
+            }
+          },
+          "cui__strsim-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "cui__cfg-if-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__hashbrown-0.12.3": {
@@ -10686,17 +6931,17 @@
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.cexpr-0.6.0.bazel"
             }
           },
-          "cui__num-bigint-0.1.44": {
+          "cui__indexmap-2.6.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1",
+              "sha256": "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/num-bigint/0.1.44/download"
+                "https://static.crates.io/crates/indexmap/2.6.0/download"
               ],
-              "strip_prefix": "num-bigint-0.1.44",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-bigint-0.1.44.bazel"
+              "strip_prefix": "indexmap-2.6.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.indexmap-2.6.0.bazel"
             }
           },
           "cui__nu-ansi-term-0.46.0": {
@@ -10738,6 +6983,19 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
             }
           },
+          "cui__gix-packetline-blocking-0.17.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b9802304baa798dd6f5ff8008a2b6516d54b74a69ca2d3a2b9e2d6c3b5556b40",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-packetline-blocking/0.17.5/download"
+              ],
+              "strip_prefix": "gix-packetline-blocking-0.17.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-packetline-blocking-0.17.5.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__serde_derive-1.0.171": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10751,82 +7009,56 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
             }
           },
-          "rules_rust_bindgen__anstyle-1.0.0": {
+          "cui__gix-command-0.3.9": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d",
+              "sha256": "dff2e692b36bbcf09286c70803006ca3fd56551a311de450be317a0ab8ea92e7",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/anstyle/1.0.0/download"
+                "https://static.crates.io/crates/gix-command/0.3.9/download"
               ],
-              "strip_prefix": "anstyle-1.0.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-1.0.0.bazel"
+              "strip_prefix": "gix-command-0.3.9",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-command-0.3.9.bazel"
             }
           },
-          "cui__gix-packetline-0.16.7": {
+          "cui__thiserror-impl-1.0.50": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "8a8384b1e964151aff0d5632dd9b191059d07dff358b96bd940f1b452600d7ab",
+              "sha256": "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-packetline/0.16.7/download"
+                "https://static.crates.io/crates/thiserror-impl/1.0.50/download"
               ],
-              "strip_prefix": "gix-packetline-0.16.7",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-packetline-0.16.7.bazel"
+              "strip_prefix": "thiserror-impl-1.0.50",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thiserror-impl-1.0.50.bazel"
             }
           },
-          "cui__time-macros-0.2.18": {
+          "rules_rust_prost__try-lock-0.2.5": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf",
+              "sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/time-macros/0.2.18/download"
+                "https://static.crates.io/crates/try-lock/0.2.5/download"
               ],
-              "strip_prefix": "time-macros-0.2.18",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-macros-0.2.18.bazel"
+              "strip_prefix": "try-lock-0.2.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.try-lock-0.2.5.bazel"
             }
           },
-          "cui__time-core-0.1.2": {
+          "rules_rust_bindgen__windows-sys-0.52.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3",
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/time-core/0.1.2/download"
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
               ],
-              "strip_prefix": "time-core-0.1.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-core-0.1.2.bazel"
-            }
-          },
-          "cui__itertools-0.12.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/itertools/0.12.0/download"
-              ],
-              "strip_prefix": "itertools-0.12.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.itertools-0.12.0.bazel"
-            }
-          },
-          "rules_rust_prost__try-lock-0.2.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/try-lock/0.2.4/download"
-              ],
-              "strip_prefix": "try-lock-0.2.4",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.try-lock-0.2.4.bazel"
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
             }
           },
           "cui__tera-1.19.1": {
@@ -10842,6 +7074,19 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tera-1.19.1.bazel"
             }
           },
+          "rules_rust_bindgen__anstyle-1.0.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.8/download"
+              ],
+              "strip_prefix": "anstyle-1.0.8",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-1.0.8.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__tempfile-3.6.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10855,17 +7100,17 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tempfile-3.6.0.bazel"
             }
           },
-          "rules_rust_prost__axum-core-0.3.4": {
+          "cui__thiserror-1.0.50": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c",
+              "sha256": "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/axum-core/0.3.4/download"
+                "https://static.crates.io/crates/thiserror/1.0.50/download"
               ],
-              "strip_prefix": "axum-core-0.3.4",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.axum-core-0.3.4.bazel"
+              "strip_prefix": "thiserror-1.0.50",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thiserror-1.0.50.bazel"
             }
           },
           "cui__globset-0.4.11": {
@@ -10881,6 +7126,32 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.globset-0.4.11.bazel"
             }
           },
+          "rules_rust_prost__axum-0.7.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/axum/0.7.5/download"
+              ],
+              "strip_prefix": "axum-0.7.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.axum-0.7.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstream-0.6.15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.6.15/download"
+              ],
+              "strip_prefix": "anstream-0.6.15",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstream-0.6.15.bazel"
+            }
+          },
           "cui__colorchoice-1.0.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10892,6 +7163,45 @@
               ],
               "strip_prefix": "colorchoice-1.0.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
+            }
+          },
+          "cui__errno-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.9/download"
+              ],
+              "strip_prefix": "errno-0.3.9",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.errno-0.3.9.bazel"
+            }
+          },
+          "rules_rust_proto__mio-uds-0.6.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio-uds/0.6.8/download"
+              ],
+              "strip_prefix": "mio-uds-0.6.8",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.mio-uds-0.6.8.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-fs-0.1.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-fs/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-fs-0.1.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-fs-0.1.7.bazel"
             }
           },
           "rrra__windows-sys-0.48.0": {
@@ -10907,17 +7217,43 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
             }
           },
-          "rules_rust_prost__libc-0.2.146": {
+          "rules_rust_wasm_bindgen__regex-automata-0.3.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b",
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/libc/0.2.146/download"
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
               ],
-              "strip_prefix": "libc-0.2.146",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.libc-0.2.146.bazel"
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "cui__gix-negotiate-0.15.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b4063bf329a191a9e24b6f948a17ccf6698c0380297f5e169cee4f1d2ab9475b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-negotiate/0.15.0/download"
+              ],
+              "strip_prefix": "gix-negotiate-0.15.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-negotiate-0.15.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__strsim-0.11.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.11.1/download"
+              ],
+              "strip_prefix": "strsim-0.11.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.strsim-0.11.1.bazel"
             }
           },
           "rules_rust_wasm_bindgen__itertools-0.10.5": {
@@ -10972,6 +7308,19 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-multi-value-xform-0.2.92.bazel"
             }
           },
+          "cui__typenum-1.16.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/typenum/1.16.0/download"
+              ],
+              "strip_prefix": "typenum-1.16.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.typenum-1.16.0.bazel"
+            }
+          },
           "rules_rust_proto__crossbeam-deque-0.7.4": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -10983,6 +7332,32 @@
               ],
               "strip_prefix": "crossbeam-deque-0.7.4",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-deque-0.7.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand-0.8.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.8.5/download"
+              ],
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-syntax-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.4",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-syntax-0.8.4.bazel"
             }
           },
           "rules_rust_wasm_bindgen__rayon-1.7.0": {
@@ -11011,6 +7386,58 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.spin-0.9.8.bazel"
             }
           },
+          "cui__gix-validate-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "81f2badbb64e57b404593ee26b752c26991910fd0d81fe6f9a71c1a8309b6c86",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-validate/0.9.0/download"
+              ],
+              "strip_prefix": "gix-validate-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-validate-0.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__difflib-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/difflib/0.4.0/download"
+              ],
+              "strip_prefix": "difflib-0.4.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.difflib-0.4.0.bazel"
+            }
+          },
+          "cui__gix-pack-0.53.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3223aa342eee21e1e0e403cad8ae9caf9edca55ef84c347738d10681676fd954",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-pack/0.53.0/download"
+              ],
+              "strip_prefix": "gix-pack-0.53.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-pack-0.53.0.bazel"
+            }
+          },
+          "rules_rust_prost__syn-2.0.76": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.76/download"
+              ],
+              "strip_prefix": "syn-2.0.76",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.syn-2.0.76.bazel"
+            }
+          },
           "rules_rust_proto__winapi-0.2.8": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11022,6 +7449,19 @@
               ],
               "strip_prefix": "winapi-0.2.8",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-0.2.8.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-wincon-3.0.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/3.0.4/download"
+              ],
+              "strip_prefix": "anstyle-wincon-3.0.4",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-wincon-3.0.4.bazel"
             }
           },
           "rules_rust_wasm_bindgen__num-traits-0.2.15": {
@@ -11037,30 +7477,82 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num-traits-0.2.15.bazel"
             }
           },
-          "rules_rust_prost__heck-0.4.1": {
+          "cui__sha2-0.10.8": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+              "sha256": "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/heck/0.4.1/download"
+                "https://static.crates.io/crates/sha2/0.10.8/download"
               ],
-              "strip_prefix": "heck-0.4.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.heck-0.4.1.bazel"
+              "strip_prefix": "sha2-0.10.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sha2-0.10.8.bazel"
             }
           },
-          "cui__rand_chacha-0.3.1": {
+          "rules_rust_prost__libc-0.2.158": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "sha256": "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+                "https://static.crates.io/crates/libc/0.2.158/download"
               ],
-              "strip_prefix": "rand_chacha-0.3.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
+              "strip_prefix": "libc-0.2.158",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.libc-0.2.158.bazel"
+            }
+          },
+          "cui__clru-0.6.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clru/0.6.1/download"
+              ],
+              "strip_prefix": "clru-0.6.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clru-0.6.1.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
+          "rrra__io-lifetimes-1.0.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "rules_rust_prost__object-0.36.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/object/0.36.3/download"
+              ],
+              "strip_prefix": "object-0.36.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.object-0.36.3.bazel"
             }
           },
           "rrra__anstream-0.3.2": {
@@ -11076,30 +7568,17 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
             }
           },
-          "cui__cargo-lock-9.0.0": {
+          "rrra__bitflags-1.3.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72",
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/cargo-lock/9.0.0/download"
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
               ],
-              "strip_prefix": "cargo-lock-9.0.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo-lock-9.0.0.bazel"
-            }
-          },
-          "rules_rust_bindgen__winapi-util-0.1.5": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/winapi-util/0.1.5/download"
-              ],
-              "strip_prefix": "winapi-util-0.1.5",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
             }
           },
           "rules_rust_wasm_bindgen__buf_redux-0.8.4": {
@@ -11128,17 +7607,82 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tls-api-0.1.22.bazel"
             }
           },
-          "cui__faster-hex-0.8.1": {
+          "rules_rust_proto__fnv-1.0.7": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a",
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/faster-hex/0.8.1/download"
+                "https://static.crates.io/crates/fnv/1.0.7/download"
               ],
-              "strip_prefix": "faster-hex-0.8.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.faster-hex-0.8.1.bazel"
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "cui__gix-packetline-0.17.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8c43ef4d5fe2fa222c606731c8bdbf4481413ee4ef46d61340ec39e4df4c5e49",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-packetline/0.17.6/download"
+              ],
+              "strip_prefix": "gix-packetline-0.17.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-packetline-0.17.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__log-0.4.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.22/download"
+              ],
+              "strip_prefix": "log-0.4.22",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.log-0.4.22.bazel"
+            }
+          },
+          "cui__windows_aarch64_gnullvm-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rrra__env_logger-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.10.0/download"
+              ],
+              "strip_prefix": "env_logger-0.10.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.env_logger-0.10.0.bazel"
             }
           },
           "rules_rust_prost__hashbrown-0.12.3": {
@@ -11154,69 +7698,108 @@
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hashbrown-0.12.3.bazel"
             }
           },
-          "cui__crossbeam-0.8.2": {
+          "rules_rust_prost__tracing-core-0.1.32": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c",
+              "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/crossbeam/0.8.2/download"
+                "https://static.crates.io/crates/tracing-core/0.1.32/download"
               ],
-              "strip_prefix": "crossbeam-0.8.2",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-0.8.2.bazel"
+              "strip_prefix": "tracing-core-0.1.32",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-core-0.1.32.bazel"
             }
           },
-          "rules_rust_prost__futures-channel-0.3.28": {
+          "rules_rust_bindgen__windows_i686_msvc-0.52.6": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2",
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/futures-channel/0.3.28/download"
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
               ],
-              "strip_prefix": "futures-channel-0.3.28",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-channel-0.3.28.bazel"
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
             }
           },
-          "rules_rust_prost__scopeguard-1.1.0": {
+          "rules_rust_wasm_bindgen__aho-corasick-1.0.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/scopeguard/1.1.0/download"
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
               ],
-              "strip_prefix": "scopeguard-1.1.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
             }
           },
-          "rules_rust_prost__futures-util-0.3.28": {
+          "cui__itertools-0.13.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533",
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/futures-util/0.3.28/download"
+                "https://static.crates.io/crates/itertools/0.13.0/download"
               ],
-              "strip_prefix": "futures-util-0.3.28",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-util-0.3.28.bazel"
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
             }
           },
-          "rules_rust_prost__serde-1.0.164": {
+          "rules_rust_proto__grpc-0.6.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d",
+              "sha256": "2aaf1d741fe6f3413f1f9f71b99f5e4e26776d563475a8a53ce53a73a8534c1d",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/serde/1.0.164/download"
+                "https://static.crates.io/crates/grpc/0.6.2/download"
               ],
-              "strip_prefix": "serde-1.0.164",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.serde-1.0.164.bazel"
+              "strip_prefix": "grpc-0.6.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.grpc-0.6.2.bazel"
+            }
+          },
+          "rules_rust_prost__axum-core-0.4.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/axum-core/0.4.3/download"
+              ],
+              "strip_prefix": "axum-core-0.4.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.axum-core-0.4.3.bazel"
+            }
+          },
+          "cui__ucd-trie-0.1.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ucd-trie/0.1.6/download"
+              ],
+              "strip_prefix": "ucd-trie-0.1.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ucd-trie-0.1.6.bazel"
+            }
+          },
+          "rules_rust_prost__futures-channel-0.3.30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-channel/0.3.30/download"
+              ],
+              "strip_prefix": "futures-channel-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-channel-0.3.30.bazel"
             }
           },
           "cui__crossbeam-utils-0.8.16": {
@@ -11245,19 +7828,6 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-segment-0.9.0.bazel"
             }
           },
-          "cui__regex-automata-0.4.3": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/regex-automata/0.4.3/download"
-              ],
-              "strip_prefix": "regex-automata-0.4.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-automata-0.4.3.bazel"
-            }
-          },
           "rules_rust_proto__miow-0.2.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11284,43 +7854,74 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.filetime-0.2.21.bazel"
             }
           },
-          "rules_rust_prost__windows-targets-0.48.0": {
+          "rules_rust_prost__tokio-stream-0.1.15": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5",
+              "sha256": "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/windows-targets/0.48.0/download"
+                "https://static.crates.io/crates/tokio-stream/0.1.15/download"
               ],
-              "strip_prefix": "windows-targets-0.48.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-targets-0.48.0.bazel"
+              "strip_prefix": "tokio-stream-0.1.15",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-stream-0.1.15.bazel"
             }
           },
-          "rules_rust_prost__petgraph-0.6.3": {
+          "cui__serde_spanned-0.6.8": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4",
+              "sha256": "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/petgraph/0.6.3/download"
+                "https://static.crates.io/crates/serde_spanned/0.6.8/download"
               ],
-              "strip_prefix": "petgraph-0.6.3",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.petgraph-0.6.3.bazel"
+              "strip_prefix": "serde_spanned-0.6.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_spanned-0.6.8.bazel"
             }
           },
-          "cui__gix-revwalk-0.8.0": {
+          "cui__unic-ucd-segment-0.9.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e9870c6b1032f2084567710c3b2106ac603377f8d25766b8a6b7c33e6e3ca279",
+              "sha256": "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-revwalk/0.8.0/download"
+                "https://static.crates.io/crates/unic-ucd-segment/0.9.0/download"
               ],
-              "strip_prefix": "gix-revwalk-0.8.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-revwalk-0.8.0.bazel"
+              "strip_prefix": "unic-ucd-segment-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-ucd-segment-0.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__android-tzdata-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
+              ],
+              "strip_prefix": "android-tzdata-0.1.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
+            }
+          },
+          "generated_inputs_in_external_repo": {
+            "bzlFile": "@@rules_rust~//test/generated_inputs:external_repo.bzl",
+            "ruleClassName": "_generated_inputs_in_external_repo",
+            "attributes": {}
+          },
+          "rules_rust_proto__kernel32-sys-0.2.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/kernel32-sys/0.2.2/download"
+              ],
+              "strip_prefix": "kernel32-sys-0.2.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.kernel32-sys-0.2.2.bazel"
             }
           },
           "rules_rust_wasm_bindgen__windows-targets-0.48.1": {
@@ -11336,17 +7937,134 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
             }
           },
-          "rules_rust_prost__syn-1.0.109": {
+          "rules_rust_prost__mime-0.3.17": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+              "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/syn/1.0.109/download"
+                "https://static.crates.io/crates/mime/0.3.17/download"
               ],
-              "strip_prefix": "syn-1.0.109",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.syn-1.0.109.bazel"
+              "strip_prefix": "mime-0.3.17",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.mime-0.3.17.bazel"
+            }
+          },
+          "rules_rust_prost__petgraph-0.6.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/petgraph/0.6.5/download"
+              ],
+              "strip_prefix": "petgraph-0.6.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.petgraph-0.6.5.bazel"
+            }
+          },
+          "rules_rust_prost__futures-util-0.3.30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-util/0.3.30/download"
+              ],
+              "strip_prefix": "futures-util-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-util-0.3.30.bazel"
+            }
+          },
+          "cui__crates-index-3.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "45fbf3a2a2f3435363fb343f30ee31d9f63ea3862d6eab639446c1393d82cd32",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crates-index/3.2.0/download"
+              ],
+              "strip_prefix": "crates-index-3.2.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crates-index-3.2.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "rrra__linux-raw-sys-0.3.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_builder-4.5.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.5.17/download"
+              ],
+              "strip_prefix": "clap_builder-4.5.17",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_builder-4.5.17.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-reactor-0.1.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-reactor/0.1.12/download"
+              ],
+              "strip_prefix": "tokio-reactor-0.1.12",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-reactor-0.1.12.bazel"
+            }
+          },
+          "cui__gix-credentials-0.24.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8ce391d305968782f1ae301c4a3d42c5701df7ff1d8bc03740300f6fd12bce78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-credentials/0.24.5/download"
+              ],
+              "strip_prefix": "gix-credentials-0.24.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-credentials-0.24.5.bazel"
             }
           },
           "cui__percent-encoding-2.3.1": {
@@ -11375,17 +8093,121 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hashbrown-0.14.0.bazel"
             }
           },
-          "cui__toml_datetime-0.6.5": {
+          "cui__windows_i686_msvc-0.52.6": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1",
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/toml_datetime/0.6.5/download"
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
               ],
-              "strip_prefix": "toml_datetime-0.6.5",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_datetime-0.6.5.bazel"
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__parking_lot_core-0.9.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.9.10/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.9.10",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.parking_lot_core-0.9.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__equivalent-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__memchr-2.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.7.4/download"
+              ],
+              "strip_prefix": "memchr-2.7.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.memchr-2.7.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__fallible-iterator-0.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fallible-iterator/0.2.0/download"
+              ],
+              "strip_prefix": "fallible-iterator-0.2.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.fallible-iterator-0.2.0.bazel"
+            }
+          },
+          "cui__pest_derive-2.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_derive/2.7.0/download"
+              ],
+              "strip_prefix": "pest_derive-2.7.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_derive-2.7.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-util-0.1.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.9/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.9",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-util-0.1.9.bazel"
+            }
+          },
+          "rules_rust_prost__heck-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.5.0/download"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "cui__toml_datetime-0.6.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_datetime/0.6.8/download"
+              ],
+              "strip_prefix": "toml_datetime-0.6.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_datetime-0.6.8.bazel"
             }
           },
           "rules_rust_proto__log-0.4.17": {
@@ -11401,6 +8223,19 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.log-0.4.17.bazel"
             }
           },
+          "cui__gix-quote-0.4.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-quote/0.4.12/download"
+              ],
+              "strip_prefix": "gix-quote-0.4.12",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-quote-0.4.12.bazel"
+            }
+          },
           "cui__tinyvec-1.6.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11414,43 +8249,56 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
             }
           },
-          "cui__btoi-0.4.3": {
+          "rules_rust_proto__fuchsia-zircon-0.3.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad",
+              "sha256": "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/btoi/0.4.3/download"
+                "https://static.crates.io/crates/fuchsia-zircon/0.3.3/download"
               ],
-              "strip_prefix": "btoi-0.4.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.btoi-0.4.3.bazel"
+              "strip_prefix": "fuchsia-zircon-0.3.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-0.3.3.bazel"
             }
           },
-          "rules_rust_prost__ppv-lite86-0.2.17": {
+          "cui__hermit-abi-0.3.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
               ],
-              "strip_prefix": "ppv-lite86-0.2.17",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
             }
           },
-          "rules_rust_prost__winapi-0.3.9": {
+          "rules_rust_wasm_bindgen__regex-syntax-0.7.4": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/winapi/0.3.9/download"
+                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
               ],
-              "strip_prefix": "winapi-0.3.9",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+              "strip_prefix": "regex-syntax-0.7.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__miniz_oxide-0.7.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
             }
           },
           "rules_rust_wasm_bindgen__winapi-util-0.1.5": {
@@ -11505,6 +8353,19 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.idna-0.5.0.bazel"
             }
           },
+          "rules_rust_bindgen__windows-targets-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
+              ],
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
+            }
+          },
           "rules_rust_bindgen__yansi-term-0.1.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11518,30 +8379,95 @@
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.yansi-term-0.1.2.bazel"
             }
           },
-          "cui__toml_edit-0.22.4": {
+          "rules_rust_proto__tokio-io-0.1.13": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951",
+              "sha256": "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/toml_edit/0.22.4/download"
+                "https://static.crates.io/crates/tokio-io/0.1.13/download"
               ],
-              "strip_prefix": "toml_edit-0.22.4",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_edit-0.22.4.bazel"
+              "strip_prefix": "tokio-io-0.1.13",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-io-0.1.13.bazel"
             }
           },
-          "rules_rust_bindgen__windows_aarch64_msvc-0.48.0": {
+          "rules_rust_bindgen__clap-4.5.17": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "sha256": "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/clap/4.5.17/download"
               ],
-              "strip_prefix": "windows_aarch64_msvc-0.48.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+              "strip_prefix": "clap-4.5.17",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap-4.5.17.bazel"
+            }
+          },
+          "rules_rust_prost__prost-types-0.13.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-types/0.13.1/download"
+              ],
+              "strip_prefix": "prost-types-0.13.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-types-0.13.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicase-2.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicase/2.6.0/download"
+              ],
+              "strip_prefix": "unicase-2.6.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicase-2.6.0.bazel"
+            }
+          },
+          "rules_rust_prost__equivalent-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "rrra__unicode-ident-1.0.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-epoch-0.8.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-epoch/0.8.2/download"
+              ],
+              "strip_prefix": "crossbeam-epoch-0.8.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-epoch-0.8.2.bazel"
             }
           },
           "cui__block-buffer-0.10.4": {
@@ -11557,43 +8483,159 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.block-buffer-0.10.4.bazel"
             }
           },
-          "cui__chrono-tz-build-0.2.1": {
+          "cui__clap_lex-0.5.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f",
+              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/chrono-tz-build/0.2.1/download"
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
               ],
-              "strip_prefix": "chrono-tz-build-0.2.1",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.chrono-tz-build-0.2.1.bazel"
+              "strip_prefix": "clap_lex-0.5.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
             }
           },
-          "cui__gix-bitmap-0.2.7": {
+          "cui__gix-trace-0.1.10": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "0ccab4bc576844ddb51b78d81b4a42d73e6229660fa614dfc3d3999c874d1959",
+              "sha256": "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-bitmap/0.2.7/download"
+                "https://static.crates.io/crates/gix-trace/0.1.10/download"
               ],
-              "strip_prefix": "gix-bitmap-0.2.7",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-bitmap-0.2.7.bazel"
+              "strip_prefix": "gix-trace-0.1.10",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-trace-0.1.10.bazel"
             }
           },
-          "cui__gix-pathspec-0.3.0": {
+          "cui__hex-0.4.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "c3e26c9b47c51be73f98d38c84494bd5fb99334c5d6fda14ef5d036d50a9e5fd",
+              "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-pathspec/0.3.0/download"
+                "https://static.crates.io/crates/hex/0.4.3/download"
               ],
-              "strip_prefix": "gix-pathspec-0.3.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-pathspec-0.3.0.bazel"
+              "strip_prefix": "hex-0.4.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hex-0.4.3.bazel"
+            }
+          },
+          "rules_rust_prost__mio-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio/1.0.2/download"
+              ],
+              "strip_prefix": "mio-1.0.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.mio-1.0.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__bitflags-2.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.6.0/download"
+              ],
+              "strip_prefix": "bitflags-2.6.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bitflags-2.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows/0.48.0/download"
+              ],
+              "strip_prefix": "windows-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-0.48.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__ppv-lite86-0.2.20": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ppv-lite86/0.2.20/download"
+              ],
+              "strip_prefix": "ppv-lite86-0.2.20",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.ppv-lite86-0.2.20.bazel"
+            }
+          },
+          "rules_rust_proto__bitflags-1.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-normalization-0.1.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
+              ],
+              "strip_prefix": "unicode-normalization-0.1.22",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
+            }
+          },
+          "cargo_bazel.buildifier-linux-arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-arm64"
+              ],
+              "integrity": "sha256-C/hsS//69PCO7Xe95bIILkrlA5oR4uiwOYTBc8NKVhw=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "rules_rust_wasm_bindgen__anyhow-1.0.71": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
+              ],
+              "strip_prefix": "anyhow-1.0.71",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
             }
           },
           "rrra__libc-0.2.147": {
@@ -11622,6 +8664,71 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.base64-0.21.5.bazel"
             }
           },
+          "rules_rust_prost__byteorder-1.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/byteorder/1.5.0/download"
+              ],
+              "strip_prefix": "byteorder-1.5.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.byteorder-1.5.0.bazel"
+            }
+          },
+          "rules_rust_proto__bytes-0.4.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bytes/0.4.12/download"
+              ],
+              "strip_prefix": "bytes-0.4.12",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.bytes-0.4.12.bazel"
+            }
+          },
+          "rules_rust_prost__itoa-1.0.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.11/download"
+              ],
+              "strip_prefix": "itoa-1.0.11",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.itoa-1.0.11.bazel"
+            }
+          },
+          "rules_rust_prost__matchit-0.7.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/matchit/0.7.3/download"
+              ],
+              "strip_prefix": "matchit-0.7.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.matchit-0.7.3.bazel"
+            }
+          },
+          "cui__gix-object-0.44.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2f5b801834f1de7640731820c2df6ba88d95480dc4ab166a5882f8ff12b88efa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-object/0.44.0/download"
+              ],
+              "strip_prefix": "gix-object-0.44.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-object-0.44.0.bazel"
+            }
+          },
           "cui__tracing-attributes-0.1.27": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11635,22 +8742,35 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-attributes-0.1.27.bazel"
             }
           },
+          "cui__winnow-0.6.20": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winnow/0.6.20/download"
+              ],
+              "strip_prefix": "winnow-0.6.20",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winnow-0.6.20.bazel"
+            }
+          },
           "rules_rust_test_load_arbitrary_tool": {
             "bzlFile": "@@rules_rust~//test/load_arbitrary_tool:load_arbitrary_tool_test.bzl",
             "ruleClassName": "_load_arbitrary_tool_test",
             "attributes": {}
           },
-          "rules_rust_prost__tokio-1.28.2": {
+          "rules_rust_prost__once_cell-1.19.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2",
+              "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/tokio/1.28.2/download"
+                "https://static.crates.io/crates/once_cell/1.19.0/download"
               ],
-              "strip_prefix": "tokio-1.28.2",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-1.28.2.bazel"
+              "strip_prefix": "once_cell-1.19.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.once_cell-1.19.0.bazel"
             }
           },
           "rules_rust_proto__parking_lot_core-0.6.3": {
@@ -11679,6 +8799,19 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.chunked_transfer-1.4.1.bazel"
             }
           },
+          "rules_rust_prost__sync_wrapper-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sync_wrapper/0.1.2/download"
+              ],
+              "strip_prefix": "sync_wrapper-0.1.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-0.1.2.bazel"
+            }
+          },
           "cui__tinyvec_macros-0.1.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11690,6 +8823,19 @@
               ],
               "strip_prefix": "tinyvec_macros-0.1.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_complete-4.5.26": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_complete/4.5.26/download"
+              ],
+              "strip_prefix": "clap_complete-4.5.26",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_complete-4.5.26.bazel"
             }
           },
           "rules_rust_proto__semver-parser-0.7.0": {
@@ -11731,6 +8877,45 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-udp-0.1.6.bazel"
             }
           },
+          "rules_rust_wasm_bindgen__errno-dragonfly-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+              ],
+              "strip_prefix": "errno-dragonfly-0.1.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__rustc-hash-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
+              ],
+              "strip_prefix": "rustc-hash-1.1.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
+            }
+          },
+          "cui__gix-chunk-0.4.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-chunk/0.4.8/download"
+              ],
+              "strip_prefix": "gix-chunk-0.4.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-chunk-0.4.8.bazel"
+            }
+          },
           "cui__unic-char-property-0.9.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11742,6 +8927,32 @@
               ],
               "strip_prefix": "unic-char-property-0.9.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-char-property-0.9.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__anyhow-1.0.86": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.86/download"
+              ],
+              "strip_prefix": "anyhow-1.0.86",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.anyhow-1.0.86.bazel"
             }
           },
           "rules_rust_wasm_bindgen__sha1_smol-1.0.0": {
@@ -11757,17 +8968,17 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
             }
           },
-          "cui__siphasher-0.3.10": {
+          "cui__gix-commitgraph-0.24.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de",
+              "sha256": "133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/siphasher/0.3.10/download"
+                "https://static.crates.io/crates/gix-commitgraph/0.24.3/download"
               ],
-              "strip_prefix": "siphasher-0.3.10",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.siphasher-0.3.10.bazel"
+              "strip_prefix": "gix-commitgraph-0.24.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-commitgraph-0.24.3.bazel"
             }
           },
           "cui__tracing-0.1.40": {
@@ -11822,6 +9033,32 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
             }
           },
+          "rules_rust_prost__tracing-attributes-0.1.27": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-attributes/0.1.27/download"
+              ],
+              "strip_prefix": "tracing-attributes-0.1.27",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-attributes-0.1.27.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__chrono-0.4.26": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono/0.4.26/download"
+              ],
+              "strip_prefix": "chrono-0.4.26",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
+            }
+          },
           "rrra__errno-dragonfly-0.1.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11848,6 +9085,32 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.instant-0.1.12.bazel"
             }
           },
+          "rules_rust_prost__linux-raw-sys-0.4.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.4.14/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.4.14",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.linux-raw-sys-0.4.14.bazel"
+            }
+          },
+          "cui__same-file-1.0.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/same-file/1.0.6/download"
+              ],
+              "strip_prefix": "same-file-1.0.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.same-file-1.0.6.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__regex-automata-0.1.10": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11859,6 +9122,32 @@
               ],
               "strip_prefix": "regex-automata-0.1.10",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.1.10.bazel"
+            }
+          },
+          "cui__linux-raw-sys-0.3.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "cui__toml-0.8.19": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml/0.8.19/download"
+              ],
+              "strip_prefix": "toml-0.8.19",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml-0.8.19.bazel"
             }
           },
           "rrra__hermit-abi-0.3.2": {
@@ -11874,17 +9163,30 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
             }
           },
-          "rules_rust_bindgen__strsim-0.10.0": {
+          "rules_rust_wasm_bindgen__rand_core-0.6.4": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/strsim/0.10.0/download"
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
               ],
-              "strip_prefix": "strsim-0.10.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "cui__crossbeam-channel-0.5.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
+              ],
+              "strip_prefix": "crossbeam-channel-0.5.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
             }
           },
           "cui__arrayvec-0.7.4": {
@@ -11900,17 +9202,56 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.arrayvec-0.7.4.bazel"
             }
           },
-          "rules_rust_prost__errno-0.3.1": {
+          "rules_rust_prost__rand-0.8.5": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/errno/0.3.1/download"
+                "https://static.crates.io/crates/rand/0.8.5/download"
               ],
-              "strip_prefix": "errno-0.3.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
+          "cui__is-terminal-0.4.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
+            }
+          },
+          "cui__unicode-width-0.1.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-width/0.1.10/download"
+              ],
+              "strip_prefix": "unicode-width-0.1.10",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-width-0.1.10.bazel"
             }
           },
           "rules_rust_proto__tokio-timer-0.1.2": {
@@ -11926,6 +9267,19 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.1.2.bazel"
             }
           },
+          "rules_rust_bindgen__clap_lex-0.7.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.7.2/download"
+              ],
+              "strip_prefix": "clap_lex-0.7.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_lex-0.7.2.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__js-sys-0.3.64": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -11937,6 +9291,32 @@
               ],
               "strip_prefix": "js-sys-0.3.64",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.js-sys-0.3.64.bazel"
+            }
+          },
+          "rrra__humantime-2.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__libc-0.2.150": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.150/download"
+              ],
+              "strip_prefix": "libc-0.2.150",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.libc-0.2.150.bazel"
             }
           },
           "rules_rust_wasm_bindgen__time-0.3.23": {
@@ -11952,17 +9332,82 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.time-0.3.23.bazel"
             }
           },
-          "cui__gix-transport-0.37.0": {
+          "rules_rust_prost__errno-0.3.9": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "b9ec726e6a245e68ace59a34126a1d679de60360676612985e70b0d3b102fb4e",
+              "sha256": "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-transport/0.37.0/download"
+                "https://static.crates.io/crates/errno/0.3.9/download"
               ],
-              "strip_prefix": "gix-transport-0.37.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-transport-0.37.0.bazel"
+              "strip_prefix": "errno-0.3.9",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.errno-0.3.9.bazel"
+            }
+          },
+          "rules_rust_bindgen__env_logger-0.10.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.10.2/download"
+              ],
+              "strip_prefix": "env_logger-0.10.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.env_logger-0.10.2.bazel"
+            }
+          },
+          "rules_rust_prost__backtrace-0.3.73": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/backtrace/0.3.73/download"
+              ],
+              "strip_prefix": "backtrace-0.3.73",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.backtrace-0.3.73.bazel"
+            }
+          },
+          "rules_rust_prost__aho-corasick-1.1.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.3/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.aho-corasick-1.1.3.bazel"
+            }
+          },
+          "rules_rust_prost__sync_wrapper-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sync_wrapper/1.0.1/download"
+              ],
+              "strip_prefix": "sync_wrapper-1.0.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-1.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper/1.4.1/download"
+              ],
+              "strip_prefix": "hyper-1.4.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-1.4.1.bazel"
             }
           },
           "rules_rust_proto__net2-0.2.38": {
@@ -11978,30 +9423,95 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.net2-0.2.38.bazel"
             }
           },
-          "rules_rust_prost__pin-project-internal-1.1.0": {
+          "rules_rust_wasm_bindgen__indexmap-2.0.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07",
+              "sha256": "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/pin-project-internal/1.1.0/download"
+                "https://static.crates.io/crates/indexmap/2.0.0/download"
               ],
-              "strip_prefix": "pin-project-internal-1.1.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-internal-1.1.0.bazel"
+              "strip_prefix": "indexmap-2.0.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.indexmap-2.0.0.bazel"
             }
           },
-          "cui__rustc-hash-1.1.0": {
+          "cui__windows_i686_gnu-0.48.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
               ],
-              "strip_prefix": "rustc-hash-1.1.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "rrra__proc-macro2-1.0.64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.64",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-tree-1.0.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates-tree/1.0.9/download"
+              ],
+              "strip_prefix": "predicates-tree-1.0.9",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-tree-1.0.9.bazel"
+            }
+          },
+          "rules_rust_prost__zerocopy-derive-0.7.35": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy-derive/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-derive-0.7.35",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.zerocopy-derive-0.7.35.bazel"
+            }
+          },
+          "rrra__errno-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.1/download"
+              ],
+              "strip_prefix": "errno-0.3.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__libc-0.2.158": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.158/download"
+              ],
+              "strip_prefix": "libc-0.2.158",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.libc-0.2.158.bazel"
             }
           },
           "cui__sharded-slab-0.1.7": {
@@ -12043,17 +9553,82 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
             }
           },
-          "cui__gix-commitgraph-0.21.0": {
+          "cui__arc-swap-1.6.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e75a975ee22cf0a002bfe9b5d5cb3d2a88e263a8a178cd7509133cff10f4df8a",
+              "sha256": "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-commitgraph/0.21.0/download"
+                "https://static.crates.io/crates/arc-swap/1.6.0/download"
               ],
-              "strip_prefix": "gix-commitgraph-0.21.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-commitgraph-0.21.0.bazel"
+              "strip_prefix": "arc-swap-1.6.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.arc-swap-1.6.0.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-uds-0.2.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-uds/0.2.7/download"
+              ],
+              "strip_prefix": "tokio-uds-0.2.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.2.7.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__webpki-roots-0.25.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/webpki-roots/0.25.2/download"
+              ],
+              "strip_prefix": "webpki-roots-0.25.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.webpki-roots-0.25.2.bazel"
+            }
+          },
+          "rules_rust_prost__cc-1.1.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.1.14/download"
+              ],
+              "strip_prefix": "cc-1.1.14",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.cc-1.1.14.bazel"
+            }
+          },
+          "cui__gix-lock-14.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-lock/14.0.0/download"
+              ],
+              "strip_prefix": "gix-lock-14.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-lock-14.0.0.bazel"
+            }
+          },
+          "cui__lock_api-0.4.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.4.11/download"
+              ],
+              "strip_prefix": "lock_api-0.4.11",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.lock_api-0.4.11.bazel"
             }
           },
           "rrra__serde_json-1.0.102": {
@@ -12069,17 +9644,17 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
             }
           },
-          "rules_rust_prost__tonic-build-0.8.4": {
+          "cui__libc-0.2.161": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4",
+              "sha256": "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/tonic-build/0.8.4/download"
+                "https://static.crates.io/crates/libc/0.2.161/download"
               ],
-              "strip_prefix": "tonic-build-0.8.4",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tonic-build-0.8.4.bazel"
+              "strip_prefix": "libc-0.2.161",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.libc-0.2.161.bazel"
             }
           },
           "rules_rust_wasm_bindgen__rouille-3.6.2": {
@@ -12095,17 +9670,56 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rouille-3.6.2.bazel"
             }
           },
-          "cui__anyhow-1.0.75": {
+          "rules_rust_prost__http-1.1.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6",
+              "sha256": "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/anyhow/1.0.75/download"
+                "https://static.crates.io/crates/http/1.1.0/download"
               ],
-              "strip_prefix": "anyhow-1.0.75",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anyhow-1.0.75.bazel"
+              "strip_prefix": "http-1.1.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-1.1.0.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-internal-1.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-internal/1.1.5/download"
+              ],
+              "strip_prefix": "pin-project-internal-1.1.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-internal-1.1.5.bazel"
+            }
+          },
+          "rules_rust_prost__addr2line-0.22.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/addr2line/0.22.0/download"
+              ],
+              "strip_prefix": "addr2line-0.22.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.addr2line-0.22.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__url-2.4.0": {
@@ -12147,56 +9761,134 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.syn-1.0.109.bazel"
             }
           },
-          "rules_rust_prost__socket2-0.4.9": {
+          "rules_rust_wasm_bindgen__ascii-1.1.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662",
+              "sha256": "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/socket2/0.4.9/download"
+                "https://static.crates.io/crates/ascii/1.1.0/download"
               ],
-              "strip_prefix": "socket2-0.4.9",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.socket2-0.4.9.bazel"
+              "strip_prefix": "ascii-1.1.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ascii-1.1.0.bazel"
             }
           },
-          "rules_rust_prost__futures-sink-0.3.28": {
+          "rules_rust_wasm_bindgen__bstr-0.2.17": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e",
+              "sha256": "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/futures-sink/0.3.28/download"
+                "https://static.crates.io/crates/bstr/0.2.17/download"
               ],
-              "strip_prefix": "futures-sink-0.3.28",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-sink-0.3.28.bazel"
+              "strip_prefix": "bstr-0.2.17",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bstr-0.2.17.bazel"
             }
           },
-          "rules_rust_prost__unicode-ident-1.0.9": {
+          "cui__allocator-api2-0.2.18": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0",
+              "sha256": "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/unicode-ident/1.0.9/download"
+                "https://static.crates.io/crates/allocator-api2/0.2.18/download"
               ],
-              "strip_prefix": "unicode-ident-1.0.9",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.unicode-ident-1.0.9.bazel"
+              "strip_prefix": "allocator-api2-0.2.18",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.allocator-api2-0.2.18.bazel"
             }
           },
-          "cui__libc-0.2.149": {
+          "rules_rust_prost__protoc-gen-tonic-0.4.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b",
+              "sha256": "6ab6a0d73a0914752ed8fd7cc51afe169e28da87be3efef292de5676cc527634",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/libc/0.2.149/download"
+                "https://static.crates.io/crates/protoc-gen-tonic/0.4.1/download"
               ],
-              "strip_prefix": "libc-0.2.149",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.libc-0.2.149.bazel"
+              "strip_prefix": "protoc-gen-tonic-0.4.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-tonic-0.4.1.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_proto__rustc_version-0.2.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc_version/0.2.3/download"
+              ],
+              "strip_prefix": "rustc_version-0.2.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.rustc_version-0.2.3.bazel"
+            }
+          },
+          "rules_rust_bindgen__is_terminal_polyfill-1.70.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is_terminal_polyfill/1.70.1/download"
+              ],
+              "strip_prefix": "is_terminal_polyfill-1.70.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.is_terminal_polyfill-1.70.1.bazel"
+            }
+          },
+          "cui__aho-corasick-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__syn-2.0.77": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.77/download"
+              ],
+              "strip_prefix": "syn-2.0.77",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.syn-2.0.77.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tinyvec-1.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec/1.6.0/download"
+              ],
+              "strip_prefix": "tinyvec-1.6.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
             }
           },
           "cui__unicode-linebreak-0.1.5": {
@@ -12238,19 +9930,6 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.itertools-0.11.0.bazel"
             }
           },
-          "rules_rust_bindgen__regex-1.8.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/regex/1.8.4/download"
-              ],
-              "strip_prefix": "regex-1.8.4",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-1.8.4.bazel"
-            }
-          },
           "cui__hashbrown-0.14.3": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -12290,17 +9969,121 @@
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
             }
           },
-          "cui__byteyarn-0.2.3": {
+          "rules_rust_proto__winapi-x86_64-pc-windows-gnu-0.4.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "a7534301c0ea17abb4db06d75efc7b4b0fa360fce8e175a4330d721c71c942ff",
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/byteyarn/0.2.3/download"
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
               ],
-              "strip_prefix": "byteyarn-0.2.3",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.byteyarn-0.2.3.bazel"
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "cui__windows_i686_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-utils-0.8.16": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.8.16",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
+            }
+          },
+          "rules_rust_prost__futures-sink-0.3.30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-sink/0.3.30/download"
+              ],
+              "strip_prefix": "futures-sink-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-sink-0.3.30.bazel"
+            }
+          },
+          "cui__anyhow-1.0.89": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.89/download"
+              ],
+              "strip_prefix": "anyhow-1.0.89",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anyhow-1.0.89.bazel"
+            }
+          },
+          "cui__gix-config-0.40.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78e797487e6ca3552491de1131b4f72202f282fb33f198b1c34406d765b42bb0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-config/0.40.0/download"
+              ],
+              "strip_prefix": "gix-config-0.40.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-config-0.40.0.bazel"
+            }
+          },
+          "rules_rust_prost__regex-1.10.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.10.6/download"
+              ],
+              "strip_prefix": "regex-1.10.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-1.10.6.bazel"
+            }
+          },
+          "cui__memchr-2.6.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.6.4/download"
+              ],
+              "strip_prefix": "memchr-2.6.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memchr-2.6.4.bazel"
+            }
+          },
+          "cui__windows-targets-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
+              ],
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
             }
           },
           "rules_rust_proto__tokio-executor-0.1.10": {
@@ -12316,6 +10099,45 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-executor-0.1.10.bazel"
             }
           },
+          "rules_rust_prost__quote-1.0.37": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
+          "rrra__serde_derive-1.0.171": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.171/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.171",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
+            }
+          },
+          "rules_rust_prost__http-body-util-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http-body-util/0.1.2/download"
+              ],
+              "strip_prefix": "http-body-util-0.1.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-body-util-0.1.2.bazel"
+            }
+          },
           "rules_rust_proto__tokio-uds-0.1.7": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -12329,30 +10151,30 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.1.7.bazel"
             }
           },
-          "rules_rust_prost__io-lifetimes-1.0.11": {
+          "cui__bitflags-2.4.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "sha256": "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+                "https://static.crates.io/crates/bitflags/2.4.1/download"
               ],
-              "strip_prefix": "io-lifetimes-1.0.11",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+              "strip_prefix": "bitflags-2.4.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bitflags-2.4.1.bazel"
             }
           },
-          "rules_rust_prost__itoa-1.0.6": {
+          "rrra__windows_aarch64_gnullvm-0.48.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6",
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/itoa/1.0.6/download"
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
               ],
-              "strip_prefix": "itoa-1.0.6",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.itoa-1.0.6.bazel"
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__cfg-if-1.0.0": {
@@ -12368,32 +10190,6 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
             }
           },
-          "rules_rust_prost__windows_x86_64_gnullvm-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
-              ],
-              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
-            }
-          },
-          "cui__gix-credentials-0.20.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "46900b884cc5af6a6c141ee741607c0c651a4e1d33614b8d888a1ba81cc0bc8a",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-credentials/0.20.0/download"
-              ],
-              "strip_prefix": "gix-credentials-0.20.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-credentials-0.20.0.bazel"
-            }
-          },
           "rules_rust_proto__tokio-0.1.22": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -12405,6 +10201,19 @@
               ],
               "strip_prefix": "tokio-0.1.22",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-0.1.22.bazel"
+            }
+          },
+          "rules_rust_prost__serde-1.0.209": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.209/download"
+              ],
+              "strip_prefix": "serde-1.0.209",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.serde-1.0.209.bazel"
             }
           },
           "rules_rust_proto__tls-api-stub-0.1.22": {
@@ -12420,43 +10229,55 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tls-api-stub-0.1.22.bazel"
             }
           },
-          "rules_rust_prost__syn-2.0.18": {
+          "rules_rust_prost__socket2-0.5.7": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e",
+              "sha256": "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/syn/2.0.18/download"
+                "https://static.crates.io/crates/socket2/0.5.7/download"
               ],
-              "strip_prefix": "syn-2.0.18",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.syn-2.0.18.bazel"
+              "strip_prefix": "socket2-0.5.7",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.socket2-0.5.7.bazel"
             }
           },
-          "rules_rust_prost__linux-raw-sys-0.3.8": {
+          "rules_rust_proto__void-1.0.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "sha256": "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+                "https://static.crates.io/crates/void/1.0.2/download"
               ],
-              "strip_prefix": "linux-raw-sys-0.3.8",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+              "strip_prefix": "void-1.0.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.void-1.0.2.bazel"
             }
           },
-          "cui__serde_derive-1.0.190": {
+          "cargo_bazel.buildifier-linux-s390x": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-s390x"
+              ],
+              "integrity": "sha256-4tef9YhdRSdPdlMfGtvHtzoSn1nnZ/d36PveYz2dTi4=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3",
+              "sha256": "ca821da8c1ae6c87c5e94493939a206daa8587caff227c6032e0061a3d80817f",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/serde_derive/1.0.190/download"
+                "https://static.crates.io/crates/wasm-bindgen-cli-support/0.2.92/download"
               ],
-              "strip_prefix": "serde_derive-1.0.190",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_derive-1.0.190.bazel"
+              "strip_prefix": "wasm-bindgen-cli-support-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-cli-support-0.2.92.bazel"
             }
           },
           "rules_rust_wasm_bindgen__serde-1.0.171": {
@@ -12485,17 +10306,30 @@
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.httpbis-0.7.0.bazel"
             }
           },
-          "cui__gix-revision-0.22.0": {
+          "cui__camino-1.1.9": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "c8c4b15cf2ab7a35f5bcb3ef146187c8d36df0177e171ca061913cbaaa890e89",
+              "sha256": "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-revision/0.22.0/download"
+                "https://static.crates.io/crates/camino/1.1.9/download"
               ],
-              "strip_prefix": "gix-revision-0.22.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-revision-0.22.0.bazel"
+              "strip_prefix": "camino-1.1.9",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.camino-1.1.9.bazel"
+            }
+          },
+          "cui__pest_generator-2.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_generator/2.7.0/download"
+              ],
+              "strip_prefix": "pest_generator-2.7.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_generator-2.7.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__wasm-bindgen-macro-0.2.92": {
@@ -12511,32 +10345,6 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.92.bazel"
             }
           },
-          "cui__camino-1.1.6": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/camino/1.1.6/download"
-              ],
-              "strip_prefix": "camino-1.1.6",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.camino-1.1.6.bazel"
-            }
-          },
-          "rules_rust_prost__signal-hook-registry-1.4.1": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/signal-hook-registry/1.4.1/download"
-              ],
-              "strip_prefix": "signal-hook-registry-1.4.1",
-              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.signal-hook-registry-1.4.1.bazel"
-            }
-          },
           "rules_rust_proto__mio-0.6.23": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -12548,19 +10356,6 @@
               ],
               "strip_prefix": "mio-0.6.23",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.mio-0.6.23.bazel"
-            }
-          },
-          "cui__gix-config-0.30.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "c171514b40487d3f677ae37efc0f45ac980e3169f23c27eb30a70b47fdf88ab5",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/gix-config/0.30.0/download"
-              ],
-              "strip_prefix": "gix-config-0.30.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-config-0.30.0.bazel"
             }
           },
           "cui__unicode-ident-1.0.10": {
@@ -12576,6 +10371,149 @@
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
             }
           },
+          "rules_rust_prost__signal-hook-registry-1.4.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/signal-hook-registry/1.4.2/download"
+              ],
+              "strip_prefix": "signal-hook-registry-1.4.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.signal-hook-registry-1.4.2.bazel"
+            }
+          },
+          "rules_rust_prost__heck": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "integrity": "sha256-IwTgCYP4f/s4tVtES147YKiEtdMMD8p9gv4zRJu+Veo=",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/heck-0.5.0.crate"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_proto__libc-0.2.139": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.139/download"
+              ],
+              "strip_prefix": "libc-0.2.139",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.libc-0.2.139.bazel"
+            }
+          },
+          "cui__kstring-2.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/kstring/2.0.2/download"
+              ],
+              "strip_prefix": "kstring-2.0.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.kstring-2.0.2.bazel"
+            }
+          },
+          "rules_rust_prost__windows-sys-0.52.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
+            }
+          },
+          "cui__fastrand-2.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/2.1.1/download"
+              ],
+              "strip_prefix": "fastrand-2.1.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fastrand-2.1.1.bazel"
+            }
+          },
+          "cui__unic-common-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-common/0.9.0/download"
+              ],
+              "strip_prefix": "unic-common-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-common-0.9.0.bazel"
+            }
+          },
+          "cui__windows_aarch64_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__termcolor-1.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.4.1/download"
+              ],
+              "strip_prefix": "termcolor-1.4.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.termcolor-1.4.1.bazel"
+            }
+          },
+          "cui__gix-actor-0.32.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fc19e312cd45c4a66cd003f909163dc2f8e1623e30a0c0c6df3776e89b308665",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-actor/0.32.0/download"
+              ],
+              "strip_prefix": "gix-actor-0.32.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-actor-0.32.0.bazel"
+            }
+          },
+          "rules_rust_prost__tower-0.4.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower/0.4.13/download"
+              ],
+              "strip_prefix": "tower-0.4.13",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-0.4.13.bazel"
+            }
+          },
           "rules_rust_wasm_bindgen__itoa-1.0.8": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -12587,32 +10525,6 @@
               ],
               "strip_prefix": "itoa-1.0.8",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
-            }
-          },
-          "rules_rust_bindgen__libloading-0.7.4": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/libloading/0.7.4/download"
-              ],
-              "strip_prefix": "libloading-0.7.4",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.libloading-0.7.4.bazel"
-            }
-          },
-          "rules_rust_bindgen__windows_aarch64_gnullvm-0.48.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
-              ],
-              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
             }
           },
           "rules_rust_wasm_bindgen__alloc-stdlib-0.2.2": {
@@ -12628,30 +10540,30 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.alloc-stdlib-0.2.2.bazel"
             }
           },
-          "rules_rust_bindgen__peeking_take_while-0.1.2": {
+          "rules_rust_wasm_bindgen__bitflags-1.3.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099",
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/peeking_take_while/0.1.2/download"
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
               ],
-              "strip_prefix": "peeking_take_while-0.1.2",
-              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.peeking_take_while-0.1.2.bazel"
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
             }
           },
-          "cui__gix-ignore-0.8.0": {
+          "rules_rust_prost__prost-0.13.1": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "b048f443a1f6b02da4205c34d2e287e3fd45d75e8e2f06cfb216630ea9bff5e3",
+              "sha256": "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/gix-ignore/0.8.0/download"
+                "https://static.crates.io/crates/prost/0.13.1/download"
               ],
-              "strip_prefix": "gix-ignore-0.8.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-ignore-0.8.0.bazel"
+              "strip_prefix": "prost-0.13.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-0.13.1.bazel"
             }
           },
           "rules_rust_wasm_bindgen__rayon-core-1.11.0": {
@@ -12667,17 +10579,43 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rayon-core-1.11.0.bazel"
             }
           },
-          "cui__windows-0.48.0": {
+          "rules_rust_prost__shlex-1.3.0": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
+              "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
               "type": "tar.gz",
               "urls": [
-                "https://static.crates.io/crates/windows/0.48.0/download"
+                "https://static.crates.io/crates/shlex/1.3.0/download"
               ],
-              "strip_prefix": "windows-0.48.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-0.48.0.bazel"
+              "strip_prefix": "shlex-1.3.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.shlex-1.3.0.bazel"
+            }
+          },
+          "cui__utf8parse-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
+            }
+          },
+          "cui__rustc-hash-2.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-hash/2.0.0/download"
+              ],
+              "strip_prefix": "rustc-hash-2.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustc-hash-2.0.0.bazel"
             }
           }
         },
@@ -12685,52 +10623,52 @@
           "explicitRootModuleDirectDeps": [
             "rules_rust_tinyjson",
             "cui",
-            "cui__anyhow-1.0.75",
-            "cui__camino-1.1.6",
-            "cui__cargo-lock-9.0.0",
-            "cui__cargo-platform-0.1.4",
+            "cui__anyhow-1.0.89",
+            "cui__camino-1.1.9",
+            "cui__cargo-lock-10.0.0",
+            "cui__cargo-platform-0.1.7",
             "cui__cargo_metadata-0.18.1",
-            "cui__cargo_toml-0.19.2",
-            "cui__cfg-expr-0.15.5",
+            "cui__cargo_toml-0.20.5",
+            "cui__cfg-expr-0.17.0",
             "cui__clap-4.3.11",
-            "cui__crates-index-2.2.0",
+            "cui__crates-index-3.2.0",
             "cui__hex-0.4.3",
-            "cui__indoc-2.0.4",
-            "cui__itertools-0.12.0",
-            "cui__normpath-1.1.1",
-            "cui__once_cell-1.19.0",
-            "cui__pathdiff-0.2.1",
-            "cui__regex-1.10.2",
-            "cui__semver-1.0.20",
-            "cui__serde-1.0.190",
-            "cui__serde_json-1.0.108",
-            "cui__serde_starlark-0.1.14",
+            "cui__indoc-2.0.5",
+            "cui__itertools-0.13.0",
+            "cui__normpath-1.3.0",
+            "cui__once_cell-1.20.2",
+            "cui__pathdiff-0.2.2",
+            "cui__regex-1.11.0",
+            "cui__semver-1.0.23",
+            "cui__serde-1.0.210",
+            "cui__serde_json-1.0.129",
+            "cui__serde_starlark-0.1.16",
             "cui__sha2-0.10.8",
-            "cui__spdx-0.10.3",
-            "cui__tempfile-3.8.1",
+            "cui__spdx-0.10.6",
+            "cui__tempfile-3.13.0",
             "cui__tera-1.19.1",
-            "cui__textwrap-0.16.0",
-            "cui__toml-0.8.10",
+            "cui__textwrap-0.16.1",
+            "cui__toml-0.8.19",
             "cui__tracing-0.1.40",
-            "cui__tracing-subscriber-0.3.17",
+            "cui__tracing-subscriber-0.3.18",
             "cui__url-2.5.2",
             "cui__maplit-1.0.2",
-            "cui__spectral-0.6.0",
             "cargo_bazel.buildifier-darwin-amd64",
             "cargo_bazel.buildifier-darwin-arm64",
             "cargo_bazel.buildifier-linux-amd64",
             "cargo_bazel.buildifier-linux-arm64",
+            "cargo_bazel.buildifier-linux-s390x",
             "cargo_bazel.buildifier-windows-amd64.exe",
             "rules_rust_prost__heck",
             "rules_rust_prost",
-            "rules_rust_prost__h2-0.3.19",
-            "rules_rust_prost__prost-0.11.9",
-            "rules_rust_prost__prost-types-0.11.9",
-            "rules_rust_prost__protoc-gen-prost-0.2.2",
-            "rules_rust_prost__protoc-gen-tonic-0.2.2",
-            "rules_rust_prost__tokio-1.28.2",
-            "rules_rust_prost__tokio-stream-0.1.14",
-            "rules_rust_prost__tonic-0.9.2",
+            "rules_rust_prost__h2-0.4.6",
+            "rules_rust_prost__prost-0.13.1",
+            "rules_rust_prost__prost-types-0.13.1",
+            "rules_rust_prost__protoc-gen-prost-0.4.0",
+            "rules_rust_prost__protoc-gen-tonic-0.4.1",
+            "rules_rust_prost__tokio-1.39.3",
+            "rules_rust_prost__tokio-stream-0.1.15",
+            "rules_rust_prost__tonic-0.12.1",
             "rules_rust_proto__grpc-0.6.2",
             "rules_rust_proto__grpc-compiler-0.6.2",
             "rules_rust_proto__log-0.4.17",
@@ -12739,12 +10677,12 @@
             "rules_rust_proto__tls-api-0.1.22",
             "rules_rust_proto__tls-api-stub-0.1.22",
             "llvm-raw",
-            "rules_rust_bindgen__bindgen-cli-0.69.1",
-            "rules_rust_bindgen__bindgen-0.69.1",
-            "rules_rust_bindgen__clang-sys-1.6.1",
-            "rules_rust_bindgen__clap-4.3.3",
-            "rules_rust_bindgen__clap_complete-4.3.1",
-            "rules_rust_bindgen__env_logger-0.10.0",
+            "rules_rust_bindgen__bindgen-cli-0.70.1",
+            "rules_rust_bindgen__bindgen-0.70.1",
+            "rules_rust_bindgen__clang-sys-1.8.1",
+            "rules_rust_bindgen__clap-4.5.17",
+            "rules_rust_bindgen__clap_complete-4.5.26",
+            "rules_rust_bindgen__env_logger-0.10.2",
             "rrra__anyhow-1.0.71",
             "rrra__clap-4.3.11",
             "rrra__env_logger-0.10.0",
@@ -12797,23 +10735,23 @@
           ],
           [
             "rules_rust~",
-            "cui__anyhow-1.0.75",
-            "rules_rust~~i~cui__anyhow-1.0.75"
+            "cui__anyhow-1.0.89",
+            "rules_rust~~i~cui__anyhow-1.0.89"
           ],
           [
             "rules_rust~",
-            "cui__camino-1.1.6",
-            "rules_rust~~i~cui__camino-1.1.6"
+            "cui__camino-1.1.9",
+            "rules_rust~~i~cui__camino-1.1.9"
           ],
           [
             "rules_rust~",
-            "cui__cargo-lock-9.0.0",
-            "rules_rust~~i~cui__cargo-lock-9.0.0"
+            "cui__cargo-lock-10.0.0",
+            "rules_rust~~i~cui__cargo-lock-10.0.0"
           ],
           [
             "rules_rust~",
-            "cui__cargo-platform-0.1.4",
-            "rules_rust~~i~cui__cargo-platform-0.1.4"
+            "cui__cargo-platform-0.1.7",
+            "rules_rust~~i~cui__cargo-platform-0.1.7"
           ],
           [
             "rules_rust~",
@@ -12822,13 +10760,13 @@
           ],
           [
             "rules_rust~",
-            "cui__cargo_toml-0.19.2",
-            "rules_rust~~i~cui__cargo_toml-0.19.2"
+            "cui__cargo_toml-0.20.5",
+            "rules_rust~~i~cui__cargo_toml-0.20.5"
           ],
           [
             "rules_rust~",
-            "cui__cfg-expr-0.15.5",
-            "rules_rust~~i~cui__cfg-expr-0.15.5"
+            "cui__cfg-expr-0.17.0",
+            "rules_rust~~i~cui__cfg-expr-0.17.0"
           ],
           [
             "rules_rust~",
@@ -12837,8 +10775,8 @@
           ],
           [
             "rules_rust~",
-            "cui__crates-index-2.2.0",
-            "rules_rust~~i~cui__crates-index-2.2.0"
+            "cui__crates-index-3.2.0",
+            "rules_rust~~i~cui__crates-index-3.2.0"
           ],
           [
             "rules_rust~",
@@ -12847,13 +10785,13 @@
           ],
           [
             "rules_rust~",
-            "cui__indoc-2.0.4",
-            "rules_rust~~i~cui__indoc-2.0.4"
+            "cui__indoc-2.0.5",
+            "rules_rust~~i~cui__indoc-2.0.5"
           ],
           [
             "rules_rust~",
-            "cui__itertools-0.12.0",
-            "rules_rust~~i~cui__itertools-0.12.0"
+            "cui__itertools-0.13.0",
+            "rules_rust~~i~cui__itertools-0.13.0"
           ],
           [
             "rules_rust~",
@@ -12862,43 +10800,43 @@
           ],
           [
             "rules_rust~",
-            "cui__normpath-1.1.1",
-            "rules_rust~~i~cui__normpath-1.1.1"
+            "cui__normpath-1.3.0",
+            "rules_rust~~i~cui__normpath-1.3.0"
           ],
           [
             "rules_rust~",
-            "cui__once_cell-1.19.0",
-            "rules_rust~~i~cui__once_cell-1.19.0"
+            "cui__once_cell-1.20.2",
+            "rules_rust~~i~cui__once_cell-1.20.2"
           ],
           [
             "rules_rust~",
-            "cui__pathdiff-0.2.1",
-            "rules_rust~~i~cui__pathdiff-0.2.1"
+            "cui__pathdiff-0.2.2",
+            "rules_rust~~i~cui__pathdiff-0.2.2"
           ],
           [
             "rules_rust~",
-            "cui__regex-1.10.2",
-            "rules_rust~~i~cui__regex-1.10.2"
+            "cui__regex-1.11.0",
+            "rules_rust~~i~cui__regex-1.11.0"
           ],
           [
             "rules_rust~",
-            "cui__semver-1.0.20",
-            "rules_rust~~i~cui__semver-1.0.20"
+            "cui__semver-1.0.23",
+            "rules_rust~~i~cui__semver-1.0.23"
           ],
           [
             "rules_rust~",
-            "cui__serde-1.0.190",
-            "rules_rust~~i~cui__serde-1.0.190"
+            "cui__serde-1.0.210",
+            "rules_rust~~i~cui__serde-1.0.210"
           ],
           [
             "rules_rust~",
-            "cui__serde_json-1.0.108",
-            "rules_rust~~i~cui__serde_json-1.0.108"
+            "cui__serde_json-1.0.129",
+            "rules_rust~~i~cui__serde_json-1.0.129"
           ],
           [
             "rules_rust~",
-            "cui__serde_starlark-0.1.14",
-            "rules_rust~~i~cui__serde_starlark-0.1.14"
+            "cui__serde_starlark-0.1.16",
+            "rules_rust~~i~cui__serde_starlark-0.1.16"
           ],
           [
             "rules_rust~",
@@ -12907,18 +10845,13 @@
           ],
           [
             "rules_rust~",
-            "cui__spdx-0.10.3",
-            "rules_rust~~i~cui__spdx-0.10.3"
+            "cui__spdx-0.10.6",
+            "rules_rust~~i~cui__spdx-0.10.6"
           ],
           [
             "rules_rust~",
-            "cui__spectral-0.6.0",
-            "rules_rust~~i~cui__spectral-0.6.0"
-          ],
-          [
-            "rules_rust~",
-            "cui__tempfile-3.8.1",
-            "rules_rust~~i~cui__tempfile-3.8.1"
+            "cui__tempfile-3.13.0",
+            "rules_rust~~i~cui__tempfile-3.13.0"
           ],
           [
             "rules_rust~",
@@ -12927,13 +10860,13 @@
           ],
           [
             "rules_rust~",
-            "cui__textwrap-0.16.0",
-            "rules_rust~~i~cui__textwrap-0.16.0"
+            "cui__textwrap-0.16.1",
+            "rules_rust~~i~cui__textwrap-0.16.1"
           ],
           [
             "rules_rust~",
-            "cui__toml-0.8.10",
-            "rules_rust~~i~cui__toml-0.8.10"
+            "cui__toml-0.8.19",
+            "rules_rust~~i~cui__toml-0.8.19"
           ],
           [
             "rules_rust~",
@@ -12942,8 +10875,8 @@
           ],
           [
             "rules_rust~",
-            "cui__tracing-subscriber-0.3.17",
-            "rules_rust~~i~cui__tracing-subscriber-0.3.17"
+            "cui__tracing-subscriber-0.3.18",
+            "rules_rust~~i~cui__tracing-subscriber-0.3.18"
           ],
           [
             "rules_rust~",
@@ -12997,68 +10930,68 @@
           ],
           [
             "rules_rust~",
-            "rules_rust_bindgen__bindgen-0.69.1",
-            "rules_rust~~i~rules_rust_bindgen__bindgen-0.69.1"
+            "rules_rust_bindgen__bindgen-0.70.1",
+            "rules_rust~~i~rules_rust_bindgen__bindgen-0.70.1"
           ],
           [
             "rules_rust~",
-            "rules_rust_bindgen__clang-sys-1.6.1",
-            "rules_rust~~i~rules_rust_bindgen__clang-sys-1.6.1"
+            "rules_rust_bindgen__clang-sys-1.8.1",
+            "rules_rust~~i~rules_rust_bindgen__clang-sys-1.8.1"
           ],
           [
             "rules_rust~",
-            "rules_rust_bindgen__clap-4.3.3",
-            "rules_rust~~i~rules_rust_bindgen__clap-4.3.3"
+            "rules_rust_bindgen__clap-4.5.17",
+            "rules_rust~~i~rules_rust_bindgen__clap-4.5.17"
           ],
           [
             "rules_rust~",
-            "rules_rust_bindgen__clap_complete-4.3.1",
-            "rules_rust~~i~rules_rust_bindgen__clap_complete-4.3.1"
+            "rules_rust_bindgen__clap_complete-4.5.26",
+            "rules_rust~~i~rules_rust_bindgen__clap_complete-4.5.26"
           ],
           [
             "rules_rust~",
-            "rules_rust_bindgen__env_logger-0.10.0",
-            "rules_rust~~i~rules_rust_bindgen__env_logger-0.10.0"
+            "rules_rust_bindgen__env_logger-0.10.2",
+            "rules_rust~~i~rules_rust_bindgen__env_logger-0.10.2"
           ],
           [
             "rules_rust~",
-            "rules_rust_prost__h2-0.3.19",
-            "rules_rust~~i~rules_rust_prost__h2-0.3.19"
+            "rules_rust_prost__h2-0.4.6",
+            "rules_rust~~i~rules_rust_prost__h2-0.4.6"
           ],
           [
             "rules_rust~",
-            "rules_rust_prost__prost-0.11.9",
-            "rules_rust~~i~rules_rust_prost__prost-0.11.9"
+            "rules_rust_prost__prost-0.13.1",
+            "rules_rust~~i~rules_rust_prost__prost-0.13.1"
           ],
           [
             "rules_rust~",
-            "rules_rust_prost__prost-types-0.11.9",
-            "rules_rust~~i~rules_rust_prost__prost-types-0.11.9"
+            "rules_rust_prost__prost-types-0.13.1",
+            "rules_rust~~i~rules_rust_prost__prost-types-0.13.1"
           ],
           [
             "rules_rust~",
-            "rules_rust_prost__protoc-gen-prost-0.2.2",
-            "rules_rust~~i~rules_rust_prost__protoc-gen-prost-0.2.2"
+            "rules_rust_prost__protoc-gen-prost-0.4.0",
+            "rules_rust~~i~rules_rust_prost__protoc-gen-prost-0.4.0"
           ],
           [
             "rules_rust~",
-            "rules_rust_prost__protoc-gen-tonic-0.2.2",
-            "rules_rust~~i~rules_rust_prost__protoc-gen-tonic-0.2.2"
+            "rules_rust_prost__protoc-gen-tonic-0.4.1",
+            "rules_rust~~i~rules_rust_prost__protoc-gen-tonic-0.4.1"
           ],
           [
             "rules_rust~",
-            "rules_rust_prost__tokio-1.28.2",
-            "rules_rust~~i~rules_rust_prost__tokio-1.28.2"
+            "rules_rust_prost__tokio-1.39.3",
+            "rules_rust~~i~rules_rust_prost__tokio-1.39.3"
           ],
           [
             "rules_rust~",
-            "rules_rust_prost__tokio-stream-0.1.14",
-            "rules_rust~~i~rules_rust_prost__tokio-stream-0.1.14"
+            "rules_rust_prost__tokio-stream-0.1.15",
+            "rules_rust~~i~rules_rust_prost__tokio-stream-0.1.15"
           ],
           [
             "rules_rust~",
-            "rules_rust_prost__tonic-0.9.2",
-            "rules_rust~~i~rules_rust_prost__tonic-0.9.2"
+            "rules_rust_prost__tonic-0.12.1",
+            "rules_rust~~i~rules_rust_prost__tonic-0.12.1"
           ],
           [
             "rules_rust~",


### PR DESCRIPTION
It started for me with seeing that rust_analyzer LSP does not highlight `use prost::Message;` in bazel.rs. Actually looks like the `@crates//:prost` dependency was not specified explicitly, and new version of `rules_rust` catches this issue.

Build fails with below message otherwise in new `rules_rust` version if prost is not explicitly mentioned in deps:

```
error[E0432]: unresolved import `prost`
  --> src/bazel.rs:37:5
   |
37 | use prost::Message;
   |     ^^^^^ use of undeclared crate or module `prost`
```