### PR TITLE
chore: Do not wait for BES to avoid failures

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,5 +5,7 @@ query --deleted_packages=fixtures/bzlmod/root,fixtures/simple/output_base/extern
 
 build:ci --bes_results_url=https://bazel-lsp.buildbuddy.io/invocation/
 build:ci --bes_backend=grpcs://bazel-lsp.buildbuddy.io
+# Do not wait for BES upload to finish to avoid failing build if BES is not available.
+build:ci --bes_upload_mode=nowait_for_upload_complete
 build:ci --remote_cache=grpcs://bazel-lsp.buildbuddy.io
 build:ci --remote_timeout=3600


### PR DESCRIPTION
Noticed some PRs are failing due to auth issues when connecting with BES. This PR should allow to proceed those PRs in case of BES misbehaving. 