### PR TITLE
ci: Update mac runner

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ jobs:
           #   runs-on: windows-2019
           #   extension: .exe
           - name: osx-amd64
-            runs-on: macos-12
+            runs-on: macos-13
             extension: ""
           - name: osx-arm64
             runs-on: macos-14


### PR DESCRIPTION
macos-12 is now deprecated, so this updates to macos-13