### PR TITLE
Using hermetic linux C++ toolchain.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,7 @@
-# To update these lines, execute 
+# Enable platform configs below, like build:linux, test:windows etc.
+common --enable_platform_specific_config
+
+# To update these lines, execute
 # `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=fixtures/bzlmod/root,fixtures/simple/output_base/external/bar,fixtures/simple/output_base/external/foo,fixtures/simple/root,fixtures/simple/root/foo
 query --deleted_packages=fixtures/bzlmod/root,fixtures/simple/output_base/external/bar,fixtures/simple/output_base/external/foo,fixtures/simple/root,fixtures/simple/root/foo
@@ -9,3 +12,11 @@ build:ci --bes_backend=grpcs://bazel-lsp.buildbuddy.io
 build:ci --bes_upload_mode=nowait_for_upload_complete
 build:ci --remote_cache=grpcs://bazel-lsp.buildbuddy.io
 build:ci --remote_timeout=3600
+
+# Configuration required by https://github.com/uber/hermetic_cc_toolchain
+build:linux --sandbox_add_mount_pair=/tmp
+# Disable auto-detected local C++ toolchain, always use hermetic toolchains.
+build:linux --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+# Do not leak local envs into actions, esp. PATH variable.
+build --incompatible_strict_action_env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ name = "bazel-lsp"
 version = "0.6.1"
 dependencies = [
  "anyhow",
+ "cc",
  "clap",
  "either",
  "hex",
@@ -329,9 +330,11 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+version = "1.1.13"
+source = "git+https://github.com/Asana/cc-rs.git#3cd7c687771196bd2e5d36e5446bfcfa801c08ef"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1690,6 +1693,12 @@ dependencies = [
  "quote",
  "syn 2.0.59",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.79"
+cc = "1.1.13"
 clap = { version = "4.4.18", features = ["derive"] }
 either = "1.9.0"
 hex = "0.4.3"
@@ -23,3 +24,10 @@ starlark = { git = "https://github.com/facebook/starlark-rust.git", branch = "ma
 starlark_lsp = { git = "https://github.com/facebook/starlark-rust.git", branch = "main" }
 thiserror = "1.0.56"
 tonic = "0.10.2"
+
+[patch.crates-io]
+# Release v1.1.13 of https://github.com/rust-lang/cc-rs/releases/tag/cc-v1.1.13
+# patched with support for *-unknown-linux-gnu targets.
+# Patch://github.com/Asana/cc-rs/commit/3cd7c687771196bd2e5d36e5446bfcfa801c08ef
+# Zig bug: https://github.com/ziglang/zig/issues/4911
+cc = { git = "https://github.com/Asana/cc-rs.git", commit = "3cd7c687771196bd2e5d36e5446bfcfa801c08ef" }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,3 +42,21 @@ bazel_dep(
 bazel_dep(name = "protobuf", version = "27.1")
 
 register_toolchains("//prost:prost_toolchain")
+
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.1")
+
+zig_toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
+use_repo(zig_toolchains, "zig_sdk")
+
+# TODO:
+# - Add support for hermetic Windows toolchains after fix in zig around pthread.h support:
+# https://github.com/ziglang/zig/issues/10989
+# - Add support for hermetic Mac OS toolchain after hermetic_cc_toolchain fixes support:
+# https://github.com/uber/hermetic_cc_toolchain/issues/10
+
+register_toolchains(
+    # Use oldest Rust supported version of GLIBC to be as compatible as possible,
+    # see https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html
+    "@zig_sdk//toolchain:x86_64-linux-gnu.2.17",
+    "@zig_sdk//toolchain:linux_arm64_gnu.2.17",
+)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -47,6 +47,8 @@
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
     "https://bcr.bazel.build/modules/googletest/1.14.0/source.json": "2478949479000fdd7de9a3d0107ba2c85bb5f961c3ecb1aa448f52549ce310b5",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/3.1.1/MODULE.bazel": "164331a6e73093376a19eaa1eae45a94aad3245e9e79d8f31237f4a8eb6c1c41",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/3.1.1/source.json": "a2f67694b91ae575e2715fa2c5745c8c9879e7132852ef45c05b4e25a0d3b423",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
@@ -602,6 +604,55 @@
             "buildifier_prebuilt~",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@hermetic_cc_toolchain~//toolchain:ext.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "savfNVe5lHMf4Itncd4fhqgp41UPyKO5x7KBci6XiuM=",
+        "usagesDigest": "J1GjdXYer5zAVH4tTnBgq2FxO8tH9iM7qby3gFEhn6Y=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "zig_sdk": {
+            "bzlFile": "@@hermetic_cc_toolchain~//toolchain:defs.bzl",
+            "ruleClassName": "zig_repository",
+            "attributes": {
+              "version": "0.12.0",
+              "url_formats": [
+                "https://mirror.bazel.build/ziglang.org/download/{version}/zig-{host_platform}-{version}.{_ext}",
+                "https://ziglang.org/download/{version}/zig-{host_platform}-{version}.{_ext}"
+              ],
+              "host_platform_sha256": {
+                "linux-aarch64": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63",
+                "linux-x86_64": "c7ae866b8a76a568e2d5cfd31fe89cdb629bdd161fdd5018b29a4a0a17045cad",
+                "macos-aarch64": "294e224c14fd0822cfb15a35cf39aa14bd9967867999bf8bdfe3db7ddec2a27f",
+                "macos-x86_64": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311",
+                "windows-aarch64": "04c6b92689241ca7a8a59b5f12d2ca2820c09d5043c3c4808b7e93e41c7bf97b",
+                "windows-x86_64": "2199eb4c2000ddb1fba85ba78f1fcf9c1fb8b3e57658f6a627a8e513131893f5"
+              },
+              "host_platform_ext": {
+                "linux-aarch64": "tar.xz",
+                "linux-x86_64": "tar.xz",
+                "macos-aarch64": "tar.xz",
+                "macos-x86_64": "tar.xz",
+                "windows-x86_64": "zip"
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "hermetic_cc_toolchain~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "hermetic_cc_toolchain~",
+            "hermetic_cc_toolchain",
+            "hermetic_cc_toolchain~"
           ]
         ]
       }


### PR DESCRIPTION
This allows to reproducible builds as it uses specific version of C++ compiler and glibc instead of using system ones.

Under linux using the oldest supported version of glibc by Rust (2.17), this should allow user on some older platforms to use this repo right away, see e.g. https://github.com/cameron-martin/bazel-lsp/issues/38, with this change the bazel-lsp binary starts in docker image centos:7

Not supporting Windows yet, it does not compile google abseil under Widows (there is prost -> protoc -> abseil dep). Bug on zig side: https://github.com/ziglang/zig/issues/10989