### PR TITLE
chore: Update release please action location

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -76,7 +76,7 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
The previous repository has been archived, so it is now updated to use the new one.