### PR TITLE
Upgrade starlark-rust to current HEAD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 [[package]]
 name = "allocative"
 version = "0.3.3"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "allocative_derive",
  "bumpalo",
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 name = "allocative_derive"
 version = "0.3.3"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "cmp_any"
 version = "0.8.1"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 
 [[package]]
 name = "colorchoice"
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "display_container"
 version = "0.9.0"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "either",
  "indenter",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "dupe"
 version = "0.9.0"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "dupe_derive",
 ]
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "dupe_derive"
 version = "0.9.0"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -907,6 +907,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1741,7 +1750,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "starlark"
 version = "0.12.0"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "allocative",
  "anyhow",
@@ -1756,7 +1765,7 @@ dependencies = [
  "erased-serde",
  "hashbrown 0.14.3",
  "inventory",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "maplit",
  "memoffset",
  "num-bigint",
@@ -1780,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "starlark_derive"
 version = "0.12.0"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "dupe",
  "proc-macro2",
@@ -1791,13 +1800,13 @@ dependencies = [
 [[package]]
 name = "starlark_lsp"
 version = "0.12.0"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "anyhow",
  "derivative",
  "derive_more",
  "dupe",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "lsp-server",
  "lsp-types",
  "serde",
@@ -1810,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "starlark_map"
 version = "0.12.0"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "allocative",
  "dupe",
@@ -1823,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "starlark_syntax"
 version = "0.12.0"
-source = "git+https://github.com/facebook/starlark-rust.git?branch=main#abaceca2b5b43c7cc3152182d7673e64130cde36"
+source = "git+https://github.com/facebook/starlark-rust.git?branch=main#760df74a5af3e2ebb903949f74071df9dae62b95"
 dependencies = [
  "allocative",
  "annotate-snippets",

--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -36,9 +36,6 @@ use prost::Message;
 use starlark::analysis::find_call_name::AstModuleFindCallName;
 use starlark::analysis::AstModuleLint;
 use starlark::collections::SmallMap;
-use starlark::docs::get_registered_starlark_docs;
-use starlark::docs::render_docs_as_code;
-use starlark::docs::Doc;
 use starlark::docs::DocItem;
 use starlark::docs::DocModule;
 use starlark::errors::EvalMessage;
@@ -132,8 +129,6 @@ struct FilesystemCompletionOptions {
 pub(crate) struct BazelContext<Client> {
     workspaces: RefCell<HashMap<PathBuf, Rc<BazelWorkspace>>>,
     query_output_base: Option<PathBuf>,
-    pub(crate) builtin_docs: HashMap<LspUrl, String>,
-    pub(crate) builtin_symbols: HashMap<String, LspUrl>,
     pub(crate) client: Client,
 }
 
@@ -150,36 +145,11 @@ fn is_workspace_file(uri: &LspUrl) -> bool {
 
 impl<Client: BazelClient> BazelContext<Client> {
     pub(crate) fn new(client: Client, query_output_base: Option<PathBuf>) -> anyhow::Result<Self> {
-        let mut builtins: HashMap<LspUrl, Vec<Doc>> = HashMap::new();
-        let mut builtin_symbols: HashMap<String, LspUrl> = HashMap::new();
-        for doc in get_registered_starlark_docs() {
-            let uri = Self::url_for_doc(&doc);
-            builtin_symbols.insert(doc.id.name.clone(), uri.clone());
-            builtins.entry(uri).or_default().push(doc);
-        }
-        let builtin_docs = builtins
-            .into_iter()
-            .map(|(u, ds)| (u, render_docs_as_code(&ds)))
-            .collect();
-
         Ok(Self {
             workspaces: RefCell::new(HashMap::new()),
             query_output_base,
-            builtin_docs,
-            builtin_symbols,
             client,
         })
-    }
-
-    fn url_for_doc(doc: &Doc) -> LspUrl {
-        let url = match &doc.item {
-            DocItem::Module(_) => Url::parse("starlark:/native/builtins.bzl").unwrap(),
-            DocItem::Type(_) => {
-                Url::parse(&format!("starlark:/native/builtins/{}.bzl", doc.id.name)).unwrap()
-            }
-            DocItem::Member(_) => Url::parse("starlark:/native/builtins.bzl").unwrap(),
-        };
-        LspUrl::try_from(url).unwrap()
     }
 
     fn lint_module(&self, uri: &LspUrl, ast: &AstModule) -> Vec<EvalMessage> {
@@ -676,7 +646,7 @@ impl<Client: BazelClient> LspContext for BazelContext<Client> {
                 },
                 false => Err(ContextError::NotAbsolute(uri.clone()).into()),
             },
-            LspUrl::Starlark(_) => Ok(self.builtin_docs.get(uri).cloned()),
+            LspUrl::Starlark(_) => Ok(None),
             _ => Err(ContextError::WrongScheme("file://".to_owned(), uri.clone()).into()),
         }
     }
@@ -690,7 +660,7 @@ impl<Client: BazelClient> LspContext for BazelContext<Client> {
         _current_file: &LspUrl,
         symbol: &str,
     ) -> anyhow::Result<Option<LspUrl>> {
-        Ok(self.builtin_symbols.get(symbol).cloned())
+        Ok(None)
     }
 
     fn get_string_completion_options(


### PR DESCRIPTION
This PR upgrades stalark-rust to the current HEAD and contains required fixes to bazel-lsp. Previous version was from Sep 3, and there were a lot of changes in the mean time.

This fixes e.g. https://github.com/cameron-martin/bazel-lsp/issues/62

# Changes

## remove get_registered_starlark_docs

This follows change from https://github.com/facebook/starlark-rust/commit/9a7b00eecd723c026fb8dc4ffdc9a5729c6ce384 which removed it in starlark_bin

Basically get_registered_starlark_docs returned only some random symbols built in into the binary itself, namely: list, StackFrame, dict, string


## adapt to starlark-rust rewrite DocParams

Rewrite happened in https://github.com/facebook/starlark-rust/commit/723a272cafb3d0cb1a844906625f790978f125e3