### PR TITLE
chore: increase verbosity for build/test failures

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,12 @@
 # Enable platform configs below, like build:linux, test:windows etc.
 common --enable_platform_specific_config
 
+# Print full command line if action fails.
+build --verbose_failures
+
+# Print output of failed tests.
+test --test_output=errors
+
 # To update these lines, execute
 # `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=fixtures/bzlmod/root,fixtures/simple/output_base/external/bar,fixtures/simple/output_base/external/foo,fixtures/simple/root,fixtures/simple/root/foo


### PR DESCRIPTION
If action fails bazel suggest using --verbose_failures to get more info, including command line of failed command. It's usually useful to have more data about failed commands, and it effective only in case actual failure happens.

Showing output of failed tests seems to be helpful in most cases - otherwise one needs to either check the output file, or e.g. view failure in buildbuddy (if one has access).