### PR TITLE
ci: Add arm64 linux runner

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,6 +16,9 @@ jobs:
           - name: linux-amd64
             runs-on: ubuntu-20.04
             extension: ""
+          - name: linux-arm64
+            runs-on: ubuntu-22.04-arm
+            extension: ""
           - name: windows-amd64
             runs-on: windows-2019
             extension: .exe


### PR DESCRIPTION
Now that arm64 runners are available, we can build for this target. See [the release blog post](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).

Fixes #6.