### PR TITLE
ci: Update windows image

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ jobs:
             runs-on: ubuntu-24.04-arm
             extension: ""
           - name: windows-amd64
-            runs-on: windows-2019
+            runs-on: windows-2022
             extension: .exe
           - name: osx-amd64
             runs-on: macos-13


### PR DESCRIPTION
Windows 2019 is now retired by github